### PR TITLE
securedrop-sdk 0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+Changelog
+=========
+
+0.0.2
+-----
+
+* Support SDK use in a Qubes vault AppVM via securedrop-proxy (#21).
+* Add journalist UUID as an attribute on the Reply object (#19).
+
+0.0.1
+-----
+
+* Initial alpha release.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="securedrop-sdk",
-    version="0.1.0",
+    version="0.0.2",
     author="Kushal Das",
     author_email="kushal@freedom.press",
     description="Python client API to access SecureDrop Journalist REST API",


### PR DESCRIPTION
* a second alpha release of this project, needed for https://github.com/freedomofpress/securedrop-client/pull/49
* adds changelog

Btw I noticed that the tag version and the version on PyPI are both 0.0.1, but we had 0.1.0 in `setup.py`, we should make sure that these are consistent going forward 