### PR TITLE
Fixes #37, get stderr text in our process in Qubes

### DIFF
--- a/sdclientapi/__init__.py
+++ b/sdclientapi/__init__.py
@@ -32,6 +32,7 @@ def json_query(data):
         ["/usr/lib/qubes/qrexec-client-vm", proxyvmname, "securedrop.Proxy"],
         stdin=PIPE,
         stdout=PIPE,
+        stderr=PIPE,
     )
     p.stdin.write(data.encode("utf-8"))
     d = p.communicate()


### PR DESCRIPTION
## How to test?

On a Qubes system, execute the following code in Python (in the dev environment of sdk).

```
from sdclientapi import *
import pyotp
import sdclientapi

totp = pyotp.TOTP("JHCOGO7VCER3EJ4L")
username = "journalist"
password = "correct horse battery staple profanity oil chewy"
server = "http://localhost:8081/"
api = API(server, username, password, str(totp.now()), proxy=True)

api.authenticate()


try:
    api.authenticate()
except sdclientapi.sdlocalobjects.BaseError:
    print("Error in auth")
```
This should not print any big error messages on the `stderr`, only our `Error in auth` message should be printed'.