### PR TITLE
Download by submission URL

### DIFF
--- a/sdclientapi/__init__.py
+++ b/sdclientapi/__init__.py
@@ -357,17 +357,6 @@ class API:
         s.source_uuid = source_uuid
         return self.get_submission(s)
 
-    def get_submission_from_url(self, url: str) -> Submission:
-        """
-        Returns the updated Submission object from the server.
-
-        :param uuid: UUID of the Submission object.
-        :param source_uuid: UUID of the source.
-        :returns: Updated submission object from the server.
-        """
-        s = Submission(download_url=url)
-        return self.get_submission(s)
-
     def get_all_submissions(self) -> List[Submission]:
         """
         Returns a list of Submission objects from the server.
@@ -454,9 +443,13 @@ class API:
 
         :returns: Tuple of sha256sum and path of the saved submission.
         """
-        path_query = "api/v1/sources/{}/submissions/{}/download".format(
-            submission.source_uuid, submission.uuid
-        )
+
+        if submission.download_url != "":
+            path_query = submission.download_url
+        else:
+            path_query = "api/v1/sources/{}/submissions/{}".format(
+                submission.source_uuid, submission.uuid
+            )
         method = "GET"
 
         if path:
@@ -495,6 +488,23 @@ class API:
             return "", filepath
         except Exception as err:
             raise BaseError(err)
+
+    def download_submission_from_url(
+            self, url: str, path: str = ""
+    ) -> Tuple[str, str]:
+        """
+        Returns a tuple of sha256sum and file path for a given Submission object. This method
+        also requires a directory path in where it will save the submission file.
+
+        :param submission: Submission object
+        :param path: Local directory path to save the submission
+
+        :returns: Tuple of sha256sum and path of the saved submission.
+        """
+        s = Submission(download_url=url)
+        shasum, filepath = self.download_submission(s, path)
+
+        return shasum, filepath
 
     def flag_source(self, source: Source) -> bool:
         """

--- a/sdclientapi/__init__.py
+++ b/sdclientapi/__init__.py
@@ -321,9 +321,12 @@ class API:
         :param submission: Submission object we want to update.
         :returns: Updated submission object from the server.
         """
-        path_query = "api/v1/sources/{}/submissions/{}".format(
-            submission.source_uuid, submission.uuid
-        )
+        if submission.download_url != "":
+            path_query = submission.download_url
+        else:
+            path_query = "api/v1/sources/{}/submissions/{}".format(
+                submission.source_uuid, submission.uuid
+            )
         method = "GET"
 
         try:
@@ -352,6 +355,17 @@ class API:
         """
         s = Submission(uuid=uuid)
         s.source_uuid = source_uuid
+        return self.get_submission(s)
+
+    def get_submission_from_url(self, url: str) -> Submission:
+        """
+        Returns the updated Submission object from the server.
+
+        :param uuid: UUID of the Submission object.
+        :param source_uuid: UUID of the source.
+        :returns: Updated submission object from the server.
+        """
+        s = Submission(download_url=url)
         return self.get_submission(s)
 
     def get_all_submissions(self) -> List[Submission]:

--- a/sdclientapi/sdlocalobjects.py
+++ b/sdclientapi/sdlocalobjects.py
@@ -95,6 +95,11 @@ class Submission:
             self.uuid = kwargs["uuid"]
             return
 
+        if ["download_url"] == list(kwargs.keys()):
+            # Means we are creating an object only for fetching from server.
+            self.download_url = kwargs["download_url"]
+            return
+
         for key in [
             "download_url",
             "filename",

--- a/sdclientapi/sdlocalobjects.py
+++ b/sdclientapi/sdlocalobjects.py
@@ -80,7 +80,7 @@ class Submission:
     This class represents a submission object in the server.
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs):
         self.download_url = ""  # type: str
         self.filename = ""  # type: str
         self.is_read = False  # type: bool
@@ -96,7 +96,6 @@ class Submission:
             return
 
         if ["download_url"] == list(kwargs.keys()):
-            # Means we are creating an object only for fetching from server.
             self.download_url = kwargs["download_url"]
             return
 


### PR DESCRIPTION
Adds the ability to download submission content using the submission's own download URL, rather than synthesizing the URL based on the source and submission UUIDs.