### PR TITLE
Rename sd-journalist to sd-proxy

### DIFF
--- a/sdclientapi/__init__.py
+++ b/sdclientapi/__init__.py
@@ -11,7 +11,7 @@ from typing import Optional, Dict, List, Tuple
 from .sdlocalobjects import *
 
 
-proxyvmname = "sd-journalist"
+proxyvmname = "sd-proxy"
 
 
 def json_query(data):


### PR DESCRIPTION
Since the proxyvm name is hardcoded in the sdk, we need to change the string to `sd-proxy` as part of https://github.com/freedomofpress/securedrop-workstation/issues/138