### PR TITLE
securedrop-sdk 0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+0.0.4
+-----
+
+* Rename default proxy VM from sd-journalist to sd-proxy (#43).
+* Get stderr text when using Qubes proxy (#38).
+* Parse reply UUID (#42).
+* Fix incorrect error message when downloading a file (#36).
+
 0.0.3
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="securedrop-sdk",
-    version="0.0.3",
+    version="0.0.4",
     author="Kushal Das",
     author_email="kushal@freedom.press",
     description="Python client API to access SecureDrop Journalist REST API",


### PR DESCRIPTION
Release of latest securedrop-sdk changes to unblock renaming of sd-journalist to sd-proxy and the merging of the send replies functionality over in the client repository. 