### PR TITLE
Pin library versions in Pipfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,4 +29,6 @@ jobs:
           path: test-results
       - store_artifacts:
           path: test-results
+      - run:
+          command: pipenv check
 destination: tr1

--- a/Pipfile
+++ b/Pipfile
@@ -7,12 +7,17 @@ verify_ssl = true
 python_version = "3.5"
 
 [dev-packages]
-vcrpy = "*"
-mypy = "*"
-pyotp = "*"
-sphinx = "*"
-pytest = "*"
-pytest-cov = "*"
+coverage = "==4.5.1"
+markupsafe = "==1.0"
+pyparsing = "==2.2.2"
+pytz = "==2018.5"
+vcrpy = "==2.0.1"
+mypy = "==0.641"
+pyotp = "==2.2.6"
+sphinx = "==1.8.1"
+pytest = "==3.9.1"
+pytest-cov = "==2.6.0"
 
 [packages]
-requests = "*"
+requests = "==2.20.0"
+urllib3 = "==1.24"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "48e88afaff5fc1d2185f12d9d60e7beccb413ebb49387f6259151f201ceb4777"
+            "sha256": "66165b2c3cd742dd3a6763416d2b0f0de98d9878c26b48987fe8983380a0ab20"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -50,6 +50,7 @@
                 "sha256:41c3db2fc01e5b907288010dec72f9d0a74e37d6994e6eb56849f59fea2265ae",
                 "sha256:8819bba37a02d143296a4d032373c4dd4aca11f6d4c9973335ca75f9c8475f59"
             ],
+            "index": "pypi",
             "version": "==1.24"
         }
     },
@@ -100,6 +101,7 @@
             "hashes": [
                 "sha256:03481e81d558d30d230bc12999e3edffe392d244349a90f4ef9b88425fac74ba",
                 "sha256:0b136648de27201056c1869a6c0d4e23f464750fd9a9ba9750b8336a244429ed",
+                "sha256:0bf8cbbd71adfff0ef1f3a1531e6402d13b7b01ac50a79c97ca15f030dba6306",
                 "sha256:10a46017fef60e16694a30627319f38a2b9b52e90182dddb6e37dcdab0f4bf95",
                 "sha256:198626739a79b09fa0a2f06e083ffd12eb55449b5f8bfdbeed1df4910b2ca640",
                 "sha256:23d341cdd4a0371820eb2b0bd6b88f5003a7438bbedb33688cd33b8eae59affd",
@@ -128,8 +130,10 @@
                 "sha256:c1bb572fab8208c400adaf06a8133ac0712179a334c09224fb11393e920abcdd",
                 "sha256:de4418dadaa1c01d497e539210cb6baa015965526ff5afc078c57ca69160108d",
                 "sha256:e05cb4d9aad6233d67e0541caa7e511fa4047ed7750ec2510d466e806e0255d6",
+                "sha256:f05a636b4564104120111800021a92e43397bc12a5c72fed7036be8556e0029e",
                 "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80"
             ],
+            "index": "pypi",
             "version": "==4.5.1"
         },
         "docutils": {
@@ -165,6 +169,7 @@
             "hashes": [
                 "sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
             ],
+            "index": "pypi",
             "version": "==1.0"
         },
         "more-itertools": {
@@ -273,6 +278,7 @@
                 "sha256:bc6c7146b91af3f567cf6daeaec360bc07d45ffec4cf5353f4d7a208ce7ca30a",
                 "sha256:d29593d8ebe7b57d6967b62494f8c72b03ac0262b1eed63826c6f788b3606401"
             ],
+            "index": "pypi",
             "version": "==2.2.2"
         },
         "pytest": {
@@ -296,6 +302,7 @@
                 "sha256:a061aa0a9e06881eb8b3b2b43f05b9439d6583c206d0a6c340ff72a7b6669053",
                 "sha256:ffb9ef1de172603304d9d2819af6f5ece76f2e85ec10692a524dd876e72bf277"
             ],
+            "index": "pypi",
             "version": "==2018.5"
         },
         "pyyaml": {
@@ -384,6 +391,7 @@
                 "sha256:41c3db2fc01e5b907288010dec72f9d0a74e37d6994e6eb56849f59fea2265ae",
                 "sha256:8819bba37a02d143296a4d032373c4dd4aca11f6d4c9973335ca75f9c8475f59"
             ],
+            "index": "pypi",
             "version": "==1.24"
         },
         "vcrpy": {


### PR DESCRIPTION
This will ensure pipenv lock command does not update package
versions unless explicitly specified in the Pipfile. Since we have automatic
security checks for vulnerabilities in python libraries, this will ensure more
consistency when building and testing our packages, and avoid drift in our requirements.txt and Pipfile.lock files.