### PR TITLE
ci: run SDK tests against latest version of API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build:
+  test-run:
     working_directory: ~/sdclientapi
     docker:
       - image: circleci/python:3.5.3
@@ -13,6 +13,7 @@ jobs:
       - restore_cache:
           key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
       - run:
+          name: Install dependencies
           command: |
             set -e
             sudo pip install pipenv
@@ -24,11 +25,68 @@ jobs:
             - "/usr/local/bin"
             - "/usr/local/lib/python3.5/site-packages"
       - run:
+          name: Run linters
           command: pipenv run make check
-      - store_test_results:
-          path: test-results
-      - store_artifacts:
-          path: test-results
       - run:
+          name: Run tests
+          command: |
+            pipenv run python -m unittest discover -v tests/
+      - run:
+          name: Check for known CVEs
           command: pipenv check
-destination: tr1
+  test-against-latest-api:
+    working_directory: ~/project
+    machine:
+      enabled: true
+    environment:
+      DOCKER_API_VERSION: 1.23
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: |
+            sudo pip install pipenv
+            pipenv install -d
+      - run:
+          name: Download SecureDrop server code
+          command: git clone https://github.com/freedomofpress/securedrop.git
+      - run:
+          name: Start spinning up the SecureDrop server container
+          command: |
+            cd securedrop
+            make -C securedrop dev
+          background: true  
+      - run:  # As suggested in https://discuss.circleci.com/t/prevent-race-conditions-by-waiting-for-services-with-dockerize/11215
+          name: Install dockerize
+          command: |
+            wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz &&
+            sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz &&
+            rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+          environment:
+            DOCKERIZE_VERSION: v0.6.1
+      - run:
+          name: Wait for server to be up
+          command: |
+            dockerize -wait tcp://127.0.0.1:8080 -timeout 15m
+            sleep 10
+      - run:
+          name: Remove VCR cassettes and run tests against latest API
+          command: |
+            rm data/*.yml  # Removing VCR cassettes
+            pipenv run python -m unittest discover -v tests/
+workflows:
+  version: 2
+  securedrop_ci:
+    jobs:
+      - test-run
+      - test-against-latest-api
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 4 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - test-against-latest-api

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           name: Start spinning up the SecureDrop server container
           command: |
             cd securedrop
-            make -C securedrop dev
+            NUM_SOURCES=5 make -C securedrop dev
           background: true  
       - run:  # As suggested in https://discuss.circleci.com/t/prevent-race-conditions-by-waiting-for-services-with-dockerize/11215
           name: Install dockerize
@@ -65,10 +65,10 @@ jobs:
           environment:
             DOCKERIZE_VERSION: v0.6.1
       - run:
-          name: Wait for server to be up
+          name: Wait for server to be up and for test sources to load
           command: |
             dockerize -wait tcp://127.0.0.1:8080 -timeout 15m
-            sleep 10
+            sleep 30
       - run:
           name: Remove VCR cassettes and run tests against latest API
           command: |

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -444,20 +444,20 @@
         },
         "yarl": {
             "hashes": [
-                "sha256:024ecdc12bc02b321bc66b41327f930d1c2c543fa9a561b39861da9388ba7aa9",
-                "sha256:2f3010703295fbe1aec51023740871e64bb9664c789cba5a6bdf404e93f7568f",
-                "sha256:3890ab952d508523ef4881457c4099056546593fa05e93da84c7250516e632eb",
-                "sha256:3e2724eb9af5dc41648e5bb304fcf4891adc33258c6e14e2a7414ea32541e320",
-                "sha256:5badb97dd0abf26623a9982cd448ff12cb39b8e4c94032ccdedf22ce01a64842",
-                "sha256:73f447d11b530d860ca1e6b582f947688286ad16ca42256413083d13f260b7a0",
-                "sha256:7ab825726f2940c16d92aaec7d204cfc34ac26c0040da727cf8ba87255a33829",
-                "sha256:b25de84a8c20540531526dfbb0e2d2b648c13fd5dd126728c496d7c3fea33310",
-                "sha256:c6e341f5a6562af74ba55205dbd56d248daf1b5748ec48a0200ba227bb9e33f4",
-                "sha256:c9bb7c249c4432cd47e75af3864bc02d26c9594f49c82e2a28624417f0ae63b8",
-                "sha256:e060906c0c585565c718d1c3841747b61c5439af2211e185f6739a9412dfbde1"
+                "sha256:ee506bc321b455b4a410724ec9c0ad4940932553523c6e7b69f0155269793734",
+                "sha256:4c2d780cb0b669bf027da57a0834d4968ed55c89f1593cfd11be8108bff699e2",
+                "sha256:8765ebd034d0dc812a311b31251dffb434c753fc7124487912a5bca7baeb5c9b",
+                "sha256:3278209d78d534d59ee44f595e54ee4d3a164fa77319ffbd418b1978edf71748",
+                "sha256:32a52453fc20153e34d2cf99f1a2f4c3d144e320896f1f89b5ee89bb41e877be",
+                "sha256:48f3807855b69414a41e70908e502d6dbf563e3eca22f73d1344aad9270a4ff9",
+                "sha256:a2dda88459cfe50f4f6a225d2f51e3fffb0c3c18f4c3a3ac38d9dc054f8c37b0",
+                "sha256:ac574aa2c45185e038489ff8f3bebd9269dd8327e86c72d9a7f83a1d3ad9eec4",
+                "sha256:ce5963f2451661a435721d8907a824daea52aad6e3bee9b4104e75d19269cdae",
+                "sha256:cec06d4272c2ced65308daf63360daeea5061c030fe28f75e499afd735cee860",
+                "sha256:fbbb10276d53629c0300cfd4a2092e3bbfa9a5aa95cd49808e01c59492052077"
             ],
             "markers": "python_version >= '3.4'",
-            "version": "==1.3.0"
+            "version": "==1.2.0"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Python SDK for SecureDrop
 
+[![CircleCI](https://circleci.com/gh/freedomofpress/securedrop-sdk/tree/master.svg?style=svg)](https://circleci.com/gh/freedomofpress/securedrop-sdk/tree/master)
+
 This SDK provides a convenient Python interface to the [SecureDrop Journalist Interface API](https://docs.securedrop.org/en/latest/development/journalist_api.html). The development of the SDK was primarily motivated by the creation of the [SecureDrop Workstation](https://github.com/freedomofpress/securedrop-workstation) based on Qubes OS.
 
 The SDK is currently used by the [SecureDrop Client](https://github.com/freedomofpress/securedrop-client) that is a component of the SecureDrop Workstation. When used in Qubes OS, the SDK uses the [securedrop-proxy](https://github.com/freedomofpress/securedrop-proxy) service, as the VM which runs the client does not have network access by design.

--- a/data/test-delete-reply.yml
+++ b/data/test-delete-reply.yml
@@ -4,101 +4,131 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU0MDI3NjkxOCwiaWF0IjoxNTQwMjQ4MTE4fQ.eyJpZCI6MX0.fygpQy3CxB1ulUWLFz2UdrtcBKHz-fk5gyRxbcSY720]
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1Mjk3NjkxNSwiaWF0IjoxNTUyOTQ4MTE1fQ.eyJpZCI6MX0.wFd17YM9k5t7KfMJHBoAcbsW0fATcoDleZbTdv92sto]
       Connection: [keep-alive]
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
     uri: http://127.0.0.1:8081/api/v1/replies
   response:
-    body: {string: "{\n  \"replies\": [\n    {\n      \"filename\": \"3-die-hard_chancellor-reply.gpg\",
+    body: {string: "{\n  \"replies\": [\n    {\n      \"filename\": \"3-raging_azure-reply.gpg\",
         \n      \"is_deleted_by_source\": false, \n      \"journalist_username\":
-        \"journalist\", \n      \"journalist_uuid\": \"719a8c13-9352-4380-9619-3015030b0e49\",
-        \n      \"reply_url\": \"/api/v1/sources/664259e9-bd0e-41a0-85b2-bd0d618038c5/replies/68603968-b307-4607-80f7-cc7856f90f2f\",
-        \n      \"size\": 1116, \n      \"source_url\": \"/api/v1/sources/664259e9-bd0e-41a0-85b2-bd0d618038c5\",
-        \n      \"uuid\": \"68603968-b307-4607-80f7-cc7856f90f2f\"\n    }, \n    {\n
-        \     \"filename\": \"4-die-hard_chancellor-reply.gpg\", \n      \"is_deleted_by_source\":
+        \"journalist\", \n      \"journalist_uuid\": \"33ae0b48-99fd-4eb5-94b0-d98a999a8438\",
+        \n      \"reply_url\": \"/api/v1/sources/d9eb4d27-b7c8-4599-ba22-daee6d939f17/replies/0403af8d-b948-46ac-bf76-237f51f1b908\",
+        \n      \"size\": 1134, \n      \"source_url\": \"/api/v1/sources/d9eb4d27-b7c8-4599-ba22-daee6d939f17\",
+        \n      \"uuid\": \"0403af8d-b948-46ac-bf76-237f51f1b908\"\n    }, \n    {\n
+        \     \"filename\": \"4-raging_azure-reply.gpg\", \n      \"is_deleted_by_source\":
         false, \n      \"journalist_username\": \"journalist\", \n      \"journalist_uuid\":
-        \"719a8c13-9352-4380-9619-3015030b0e49\", \n      \"reply_url\": \"/api/v1/sources/664259e9-bd0e-41a0-85b2-bd0d618038c5/replies/dddc31e4-c720-4ca4-bd31-62242d91fe6c\",
-        \n      \"size\": 1116, \n      \"source_url\": \"/api/v1/sources/664259e9-bd0e-41a0-85b2-bd0d618038c5\",
-        \n      \"uuid\": \"dddc31e4-c720-4ca4-bd31-62242d91fe6c\"\n    }, \n    {\n
-        \     \"filename\": \"3-sidereal_eclipse-reply.gpg\", \n      \"is_deleted_by_source\":
+        \"33ae0b48-99fd-4eb5-94b0-d98a999a8438\", \n      \"reply_url\": \"/api/v1/sources/d9eb4d27-b7c8-4599-ba22-daee6d939f17/replies/ac8730b9-7644-434b-8ca5-996805a511c6\",
+        \n      \"size\": 1134, \n      \"source_url\": \"/api/v1/sources/d9eb4d27-b7c8-4599-ba22-daee6d939f17\",
+        \n      \"uuid\": \"ac8730b9-7644-434b-8ca5-996805a511c6\"\n    }, \n    {\n
+        \     \"filename\": \"3-untrammeled_dancing-reply.gpg\", \n      \"is_deleted_by_source\":
         false, \n      \"journalist_username\": \"journalist\", \n      \"journalist_uuid\":
-        \"719a8c13-9352-4380-9619-3015030b0e49\", \n      \"reply_url\": \"/api/v1/sources/c32cddea-ddbb-4ccc-9d22-67caa9da1b81/replies/19f7dba0-56dd-4124-9b32-07642b28d95e\",
-        \n      \"size\": 1116, \n      \"source_url\": \"/api/v1/sources/c32cddea-ddbb-4ccc-9d22-67caa9da1b81\",
-        \n      \"uuid\": \"19f7dba0-56dd-4124-9b32-07642b28d95e\"\n    }, \n    {\n
-        \     \"filename\": \"4-sidereal_eclipse-reply.gpg\", \n      \"is_deleted_by_source\":
+        \"33ae0b48-99fd-4eb5-94b0-d98a999a8438\", \n      \"reply_url\": \"/api/v1/sources/8b8325d9-20a5-4687-8bdf-f0d45408ca38/replies/dd8d3cde-2506-4fe0-a129-3a81f95dad12\",
+        \n      \"size\": 1134, \n      \"source_url\": \"/api/v1/sources/8b8325d9-20a5-4687-8bdf-f0d45408ca38\",
+        \n      \"uuid\": \"dd8d3cde-2506-4fe0-a129-3a81f95dad12\"\n    }, \n    {\n
+        \     \"filename\": \"4-untrammeled_dancing-reply.gpg\", \n      \"is_deleted_by_source\":
         false, \n      \"journalist_username\": \"journalist\", \n      \"journalist_uuid\":
-        \"719a8c13-9352-4380-9619-3015030b0e49\", \n      \"reply_url\": \"/api/v1/sources/c32cddea-ddbb-4ccc-9d22-67caa9da1b81/replies/131455ca-6135-49df-a178-4fa50238050a\",
-        \n      \"size\": 1116, \n      \"source_url\": \"/api/v1/sources/c32cddea-ddbb-4ccc-9d22-67caa9da1b81\",
-        \n      \"uuid\": \"131455ca-6135-49df-a178-4fa50238050a\"\n    }\n  ]\n}\n"}
+        \"33ae0b48-99fd-4eb5-94b0-d98a999a8438\", \n      \"reply_url\": \"/api/v1/sources/8b8325d9-20a5-4687-8bdf-f0d45408ca38/replies/849e868d-4826-47d3-b8cc-c9a1848e77c0\",
+        \n      \"size\": 1134, \n      \"source_url\": \"/api/v1/sources/8b8325d9-20a5-4687-8bdf-f0d45408ca38\",
+        \n      \"uuid\": \"849e868d-4826-47d3-b8cc-c9a1848e77c0\"\n    }\n  ]\n}\n"}
     headers:
-      Content-Length: ['1967']
+      Content-Length: ['1959']
       Content-Type: [application/json]
-      Date: ['Mon, 22 Oct 2018 23:04:56 GMT']
-      Server: [Werkzeug/0.14.1 Python/2.7.6]
-      Set-Cookie: [js=eyJleHBpcmVzIjp7IiBkIjoiVHVlLCAyMyBPY3QgMjAxOCAwMTowNDo1NiBHTVQifX0.Dq_pGA.iIM2KMQyp3YFlgF-KPoheeNv0U4;
-          HttpOnly; Path=/]
-      Vary: [Cookie]
+      Date: ['Mon, 18 Mar 2019 22:28:35 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU0MDI3NjkxOCwiaWF0IjoxNTQwMjQ4MTE4fQ.eyJpZCI6MX0.fygpQy3CxB1ulUWLFz2UdrtcBKHz-fk5gyRxbcSY720]
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1Mjk3NjkxNSwiaWF0IjoxNTUyOTQ4MTE1fQ.eyJpZCI6MX0.wFd17YM9k5t7KfMJHBoAcbsW0fATcoDleZbTdv92sto]
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: http://127.0.0.1:8081/api/v1/replies
+  response:
+    body: {string: "{\n  \"replies\": [\n    {\n      \"filename\": \"3-raging_azure-reply.gpg\",
+        \n      \"is_deleted_by_source\": false, \n      \"journalist_username\":
+        \"journalist\", \n      \"journalist_uuid\": \"33ae0b48-99fd-4eb5-94b0-d98a999a8438\",
+        \n      \"reply_url\": \"/api/v1/sources/d9eb4d27-b7c8-4599-ba22-daee6d939f17/replies/0403af8d-b948-46ac-bf76-237f51f1b908\",
+        \n      \"size\": 1134, \n      \"source_url\": \"/api/v1/sources/d9eb4d27-b7c8-4599-ba22-daee6d939f17\",
+        \n      \"uuid\": \"0403af8d-b948-46ac-bf76-237f51f1b908\"\n    }, \n    {\n
+        \     \"filename\": \"4-raging_azure-reply.gpg\", \n      \"is_deleted_by_source\":
+        false, \n      \"journalist_username\": \"journalist\", \n      \"journalist_uuid\":
+        \"33ae0b48-99fd-4eb5-94b0-d98a999a8438\", \n      \"reply_url\": \"/api/v1/sources/d9eb4d27-b7c8-4599-ba22-daee6d939f17/replies/ac8730b9-7644-434b-8ca5-996805a511c6\",
+        \n      \"size\": 1134, \n      \"source_url\": \"/api/v1/sources/d9eb4d27-b7c8-4599-ba22-daee6d939f17\",
+        \n      \"uuid\": \"ac8730b9-7644-434b-8ca5-996805a511c6\"\n    }, \n    {\n
+        \     \"filename\": \"3-untrammeled_dancing-reply.gpg\", \n      \"is_deleted_by_source\":
+        false, \n      \"journalist_username\": \"journalist\", \n      \"journalist_uuid\":
+        \"33ae0b48-99fd-4eb5-94b0-d98a999a8438\", \n      \"reply_url\": \"/api/v1/sources/8b8325d9-20a5-4687-8bdf-f0d45408ca38/replies/dd8d3cde-2506-4fe0-a129-3a81f95dad12\",
+        \n      \"size\": 1134, \n      \"source_url\": \"/api/v1/sources/8b8325d9-20a5-4687-8bdf-f0d45408ca38\",
+        \n      \"uuid\": \"dd8d3cde-2506-4fe0-a129-3a81f95dad12\"\n    }, \n    {\n
+        \     \"filename\": \"4-untrammeled_dancing-reply.gpg\", \n      \"is_deleted_by_source\":
+        false, \n      \"journalist_username\": \"journalist\", \n      \"journalist_uuid\":
+        \"33ae0b48-99fd-4eb5-94b0-d98a999a8438\", \n      \"reply_url\": \"/api/v1/sources/8b8325d9-20a5-4687-8bdf-f0d45408ca38/replies/849e868d-4826-47d3-b8cc-c9a1848e77c0\",
+        \n      \"size\": 1134, \n      \"source_url\": \"/api/v1/sources/8b8325d9-20a5-4687-8bdf-f0d45408ca38\",
+        \n      \"uuid\": \"849e868d-4826-47d3-b8cc-c9a1848e77c0\"\n    }\n  ]\n}\n"}
+    headers:
+      Content-Length: ['1959']
+      Content-Type: [application/json]
+      Date: ['Mon, 18 Mar 2019 22:28:35 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1Mjk3NjkxNSwiaWF0IjoxNTUyOTQ4MTE1fQ.eyJpZCI6MX0.wFd17YM9k5t7KfMJHBoAcbsW0fATcoDleZbTdv92sto]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: DELETE
-    uri: http://127.0.0.1:8081/api/v1/sources/664259e9-bd0e-41a0-85b2-bd0d618038c5/replies/68603968-b307-4607-80f7-cc7856f90f2f
+    uri: http://127.0.0.1:8081/api/v1/sources/d9eb4d27-b7c8-4599-ba22-daee6d939f17/replies/0403af8d-b948-46ac-bf76-237f51f1b908
   response:
     body: {string: "{\n  \"message\": \"Reply deleted\"\n}\n"}
     headers:
       Content-Length: ['33']
       Content-Type: [application/json]
-      Date: ['Mon, 22 Oct 2018 23:04:56 GMT']
-      Server: [Werkzeug/0.14.1 Python/2.7.6]
-      Set-Cookie: [js=eyJleHBpcmVzIjp7IiBkIjoiVHVlLCAyMyBPY3QgMjAxOCAwMTowNDo1NiBHTVQifX0.Dq_pGA.iIM2KMQyp3YFlgF-KPoheeNv0U4;
-          HttpOnly; Path=/]
-      Vary: [Cookie]
+      Date: ['Mon, 18 Mar 2019 22:28:35 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU0MDI3NjkxOCwiaWF0IjoxNTQwMjQ4MTE4fQ.eyJpZCI6MX0.fygpQy3CxB1ulUWLFz2UdrtcBKHz-fk5gyRxbcSY720]
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1Mjk3NjkxNSwiaWF0IjoxNTUyOTQ4MTE1fQ.eyJpZCI6MX0.wFd17YM9k5t7KfMJHBoAcbsW0fATcoDleZbTdv92sto]
       Connection: [keep-alive]
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
     uri: http://127.0.0.1:8081/api/v1/replies
   response:
-    body: {string: "{\n  \"replies\": [\n    {\n      \"filename\": \"4-die-hard_chancellor-reply.gpg\",
+    body: {string: "{\n  \"replies\": [\n    {\n      \"filename\": \"4-raging_azure-reply.gpg\",
         \n      \"is_deleted_by_source\": false, \n      \"journalist_username\":
-        \"journalist\", \n      \"journalist_uuid\": \"719a8c13-9352-4380-9619-3015030b0e49\",
-        \n      \"reply_url\": \"/api/v1/sources/664259e9-bd0e-41a0-85b2-bd0d618038c5/replies/dddc31e4-c720-4ca4-bd31-62242d91fe6c\",
-        \n      \"size\": 1116, \n      \"source_url\": \"/api/v1/sources/664259e9-bd0e-41a0-85b2-bd0d618038c5\",
-        \n      \"uuid\": \"dddc31e4-c720-4ca4-bd31-62242d91fe6c\"\n    }, \n    {\n
-        \     \"filename\": \"3-sidereal_eclipse-reply.gpg\", \n      \"is_deleted_by_source\":
+        \"journalist\", \n      \"journalist_uuid\": \"33ae0b48-99fd-4eb5-94b0-d98a999a8438\",
+        \n      \"reply_url\": \"/api/v1/sources/d9eb4d27-b7c8-4599-ba22-daee6d939f17/replies/ac8730b9-7644-434b-8ca5-996805a511c6\",
+        \n      \"size\": 1134, \n      \"source_url\": \"/api/v1/sources/d9eb4d27-b7c8-4599-ba22-daee6d939f17\",
+        \n      \"uuid\": \"ac8730b9-7644-434b-8ca5-996805a511c6\"\n    }, \n    {\n
+        \     \"filename\": \"3-untrammeled_dancing-reply.gpg\", \n      \"is_deleted_by_source\":
         false, \n      \"journalist_username\": \"journalist\", \n      \"journalist_uuid\":
-        \"719a8c13-9352-4380-9619-3015030b0e49\", \n      \"reply_url\": \"/api/v1/sources/c32cddea-ddbb-4ccc-9d22-67caa9da1b81/replies/19f7dba0-56dd-4124-9b32-07642b28d95e\",
-        \n      \"size\": 1116, \n      \"source_url\": \"/api/v1/sources/c32cddea-ddbb-4ccc-9d22-67caa9da1b81\",
-        \n      \"uuid\": \"19f7dba0-56dd-4124-9b32-07642b28d95e\"\n    }, \n    {\n
-        \     \"filename\": \"4-sidereal_eclipse-reply.gpg\", \n      \"is_deleted_by_source\":
+        \"33ae0b48-99fd-4eb5-94b0-d98a999a8438\", \n      \"reply_url\": \"/api/v1/sources/8b8325d9-20a5-4687-8bdf-f0d45408ca38/replies/dd8d3cde-2506-4fe0-a129-3a81f95dad12\",
+        \n      \"size\": 1134, \n      \"source_url\": \"/api/v1/sources/8b8325d9-20a5-4687-8bdf-f0d45408ca38\",
+        \n      \"uuid\": \"dd8d3cde-2506-4fe0-a129-3a81f95dad12\"\n    }, \n    {\n
+        \     \"filename\": \"4-untrammeled_dancing-reply.gpg\", \n      \"is_deleted_by_source\":
         false, \n      \"journalist_username\": \"journalist\", \n      \"journalist_uuid\":
-        \"719a8c13-9352-4380-9619-3015030b0e49\", \n      \"reply_url\": \"/api/v1/sources/c32cddea-ddbb-4ccc-9d22-67caa9da1b81/replies/131455ca-6135-49df-a178-4fa50238050a\",
-        \n      \"size\": 1116, \n      \"source_url\": \"/api/v1/sources/c32cddea-ddbb-4ccc-9d22-67caa9da1b81\",
-        \n      \"uuid\": \"131455ca-6135-49df-a178-4fa50238050a\"\n    }\n  ]\n}\n"}
+        \"33ae0b48-99fd-4eb5-94b0-d98a999a8438\", \n      \"reply_url\": \"/api/v1/sources/8b8325d9-20a5-4687-8bdf-f0d45408ca38/replies/849e868d-4826-47d3-b8cc-c9a1848e77c0\",
+        \n      \"size\": 1134, \n      \"source_url\": \"/api/v1/sources/8b8325d9-20a5-4687-8bdf-f0d45408ca38\",
+        \n      \"uuid\": \"849e868d-4826-47d3-b8cc-c9a1848e77c0\"\n    }\n  ]\n}\n"}
     headers:
-      Content-Length: ['1479']
+      Content-Length: ['1478']
       Content-Type: [application/json]
-      Date: ['Mon, 22 Oct 2018 23:04:56 GMT']
-      Server: [Werkzeug/0.14.1 Python/2.7.6]
-      Set-Cookie: [js=eyJleHBpcmVzIjp7IiBkIjoiVHVlLCAyMyBPY3QgMjAxOCAwMTowNDo1NiBHTVQifX0.Dq_pGA.iIM2KMQyp3YFlgF-KPoheeNv0U4;
-          HttpOnly; Path=/]
-      Vary: [Cookie]
+      Date: ['Mon, 18 Mar 2019 22:28:35 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
     status: {code: 200, message: OK}
 version: 1

--- a/data/test-delete-reply.yml
+++ b/data/test-delete-reply.yml
@@ -9,7 +9,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/replies
+    uri: http://127.0.0.1:8081/api/v1/replies
   response:
     body: {string: "{\n  \"replies\": [\n    {\n      \"filename\": \"3-die-hard_chancellor-reply.gpg\",
         \n      \"is_deleted_by_source\": false, \n      \"journalist_username\":
@@ -52,7 +52,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: DELETE
-    uri: http://localhost:8081/api/v1/sources/664259e9-bd0e-41a0-85b2-bd0d618038c5/replies/68603968-b307-4607-80f7-cc7856f90f2f
+    uri: http://127.0.0.1:8081/api/v1/sources/664259e9-bd0e-41a0-85b2-bd0d618038c5/replies/68603968-b307-4607-80f7-cc7856f90f2f
   response:
     body: {string: "{\n  \"message\": \"Reply deleted\"\n}\n"}
     headers:
@@ -74,7 +74,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/replies
+    uri: http://127.0.0.1:8081/api/v1/replies
   response:
     body: {string: "{\n  \"replies\": [\n    {\n      \"filename\": \"4-die-hard_chancellor-reply.gpg\",
         \n      \"is_deleted_by_source\": false, \n      \"journalist_username\":

--- a/data/test-delete-source.yml
+++ b/data/test-delete-source.yml
@@ -4,97 +4,128 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU0MDI3NjkxOCwiaWF0IjoxNTQwMjQ4MTE4fQ.eyJpZCI6MX0.fygpQy3CxB1ulUWLFz2UdrtcBKHz-fk5gyRxbcSY720]
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1Mjk3OTkzMSwiaWF0IjoxNTUyOTUxMTMxfQ.eyJpZCI6MX0.9P3wxI-3_VKsD2YC5HZ31pfWuqLEBJsy9aBhW_cdqXE]
       Connection: [keep-alive]
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
     uri: http://127.0.0.1:8081/api/v1/sources
   response:
-    body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/f1ed565f-ed3f-4316-9de8-56dd8af3b4a4/add_star\",
+    body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/d9eb4d27-b7c8-4599-ba22-daee6d939f17/add_star\",
         \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
-        false, \n      \"journalist_designation\": \"yellow-white fecklessness\",
-        \n      \"key\": {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFvOU64BEADXKtc0RnZlzIpI2fM7rH0fhWXJ2oJqTMl9HEX3/G4d05PqSu9R\\nxXczPVAAeCpWR+1PwiBndkeLZ3wBJX7ergkHc+c8zas41HVoPpEKydXSi3n/CgZP\\nDs8t8KbT9N6D5ZCMOGfqr3CXSTtUOYT7BRU/mo47fQgp+5EfL1TKoU7/E65KETK/\\nH7NPJY5F+LFh9X8QjpiwUTcna2l+rWVLHBmhV7s+tnSKpO8bF6ah49QbKPZV7QGG\\nsI0KGOiOK+R5eHPtkImPE2s6EvdLKOerbYD0aZI+B/71sQM2jwvjr1+1eS9iWTNs\\nYQ42ba62/3Uz+3yEk9P9/2nArxthrZZmRxrXRrVNqYBc9oAiGmxdf7aBPP3zaJmU\\nrv9maAfMEdxKIQIhhBfw+GWhT5Le21bslkwh9mnCDRTIi+Tfl/x8PtCF95jJQcF3\\nuatin3PTm2hupt7sDVDV06eM/LTgdKrxFaFn6eEyPR7LsqNRO4fHoeXONvphN+/j\\nrfgTQsfsyNlmbsaaqk2BkE6d+f8HU8g136B14TA14tpC2m/XuUvx5MZ6aHeERhAK\\nfRj4gm4YPEhJSXJRJ6orsYEdbxzq+vgWrfJTxVd9qPs2m2DOQCutRwEcbKWdHTqv\\nz3jGX569AUNGp6+4M/LSaKNw/D7xVm9MecIsQJb6AkdVJ8eyPMAHi39tywARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8VUtKQlhKN1dTTzc2R0xaN0ZBS1NKU0hRRUYz\\nT0dXTjM0VzNWVUZQWURaVFFPQ05DRDVTRzQ2U1BJSDZNNFJJWUkyRkpBMlZLNzNG\\nREROVjJGWDNMN0I2TVdYVktITTNFNFdNRkQzQT0+iQI/BBMBCgApBQJbzlOuAhsv\\nBQkB4JuSBwsJCAcDAgEGFQgCCQoLBBYCAwECHgECF4AACgkQQqyrJapUHeCs3Q/+\\nIWYg+AFSY9PJLmC/m/oqv4Y8IHfXxOxWvoiQBodbdcKxOyjTgm6QItA5jP3t+t0J\\n9CjcVCa0rSqC3/p8X/WtoZHcJCU6MmBPaDdbh+3zpKWPdHRUzdHFO7sWYmOL9Kmu\\nPmed4nz46CvfHcBjGAHeAsbsxM+3i+yPT1rKUpqPYsk4ZrAi0B4OHKowwVkV723n\\nZNlpNeQXMcwYVylR9+10vTf8lFh9hMRisk99FJ16R3p/Lamy6I1lqLiBOgDLmLt0\\nSO0qOK5jI1qTBUNDaxay7JAKpFYQftN3JzCnGJZPEsc3+Y2hJF6RPw8OlU10Bocv\\nmkM9N2pBbbiAVIqiaB0hFHxLNihnbYqhmhksxofbEqLk744fb9p8Y8yhIPw7jCZ2\\niqiGARmdAQ2ZNXaq5FqrT7nvkReONrAQ1sQ0FVk9h1A7NfYN9eqXV7U3FjnFf8Uy\\n9EvmgTYNDBGA4ZI6bgTyVI3zFeToKz9OWRnN+EunoAuvuzqzcPMTUsHsjCnMST8W\\nuTyU7nEUHN/Li9TE2vW8vvpkl46XWBNBtsD+DGwstyfjqGQfZPHDbM+Ikjo/amMw\\nod4WT07+zXlz4PGzTpEENE0MQW/eaw9iI2DqrhX++plZljoORdqDMvqzbXDWIaHc\\nYU7zX9Ff163XuaDuIDqekUo2DP83qGWq9brLfg6qxoo=\\n=jT2/\\n-----END
+        false, \n      \"journalist_designation\": \"raging azure\", \n      \"key\":
+        {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFGRfoABEADEQMD9oHNCk7gvgk6/W2kx+DkaoM1I24fDlx3soKXqmRjyK1MK\\nx/ecx6ta3I1KRIwl6Iy1QCEhGjmR3PNEY61n6n2Jv8n2NtDx31Gagp1f8ckhPtYq\\n2BP9VzxkTIqbwi6oOaKl3GCarkZD1/detSH8Sdzk9uzlE49Qn/wCsFyW69GtJBFT\\nVZ0F5hPJItXOAT1mHrRc1Hl/lsmax61rqLGuvuCxnpe3UrDKtfxL2uNKzGYm687P\\nAxVBbHE7HlOLJ8YAVlIJQzcWXHvj5yBE2U6ANYrUYqLsuOImA5Ruwb/UwhKP+zQ5\\nhGOgizEmE3NvH5Hmex2ir+Bl3FKSn8QgvbOwXhSxkNcn+YREB8exNxZJ2SH80JvQ\\ndYR0Onfcr9W2Qn4xdvpaaR1i1faGJ9Mc2O1bg/lubpJKNh0KJsqX5yZMWFbA5nQJ\\nAO7/3tU1a9BSISEc5ICeAD+DSHYc+vsDoBcN8Fmh/p0fzDAM6AXfpl5vggzhPXTN\\ncJlJGVBTPZh4SLDLmL1lvEytoLBErzjF+rYpLDrQurflN3bGdWEKoQZxwc1I5f/h\\n/v3ZkHFwIcOV1TwVfRvmYP2Q3H+86pHeFFStb1mCh0EuS+ygwMkPIirQnIpDa3iB\\nNRLTZvdQW0T8XswQWisGL/R+mKUX1HkMkqYp/lPAqmFuNtzgWcg4pTeOmQARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8M0hBT0VaUzVVSkZUQ0tOU0FGNjRHSDJaT082\\nN0NCSUhGWkxXTEdaTTI2MzYzQ1BEQ1ZERUtBSEdIWU1HVlFJTk5OUVVDQVRHREJQ\\nRFNJRlYyUEoyWFE2UFpZWllSN09VNkROWUFXST0+iQI3BBMBCgAhBQJRkX6AAhsv\\nBQsJCAcCBhUICQoLAgQWAgMBAh4BAheAAAoJEL+uIhVjsHuRvuMP/16AhT5kbRJQ\\n109ZhDfH7pOl4avUutY7OYPHDEgFR+6BwStKZcmP/1Amx+2eUcRno8dAlSbTKYFI\\nq1gss9e/xwz1xK7qtUDFxfZL2dbNq877kmCEjNY63kLkme6O6ltCxNJ+TINKK2ff\\nkOanD3t58xILFV4nxzZd2GRWy1IEYJb3OCZ9UD0alCAZcV2RHJjJoMCRqTSfW7rV\\njrZlQZEQHIocDBlYLM461ZyP/TnCwfc/quz0GoJR+qVU+hY5sYrUh1M62cT+bKxd\\nL5Rnk/4DIx89QvcQKR0l330iB9Pu16+Ks7DaOU85M17Smg7Pjc9nYsUwgS6vQQmV\\nU6Rjlfqa7JglA54cWPd9WkRlT+cUlCUlctowgpTiAA0uzc3bu6YQ7RefGU5qnLIH\\ndDtAzIDTCeJdaJZvd2MaV0KICe4mU2RpJYlDSVUfzVb/xK6vVN6maN5tnJ6dpirj\\nA6WhGl+aKA4Ou6ok1mOHLEfAcCEbUrR8FF1MPZ9/DWRYpQpJhAfBG3pSfUByf5/w\\nt3WVNpiXWet/DXwFLsUpra7sNAb5+BFaEv22Y2bFF0TEkai39PdKUnVzc7jjSRvZ\\n84cfRurWK9GR8ynSLEmu47/beWzRIO5qBe3VIdDUL2w0PhH/rKiGg5zBDy8b8otz\\n2OCPH1/t36o/CP6SrIJdE1l1Z6RoS0C/\\n=DXES\\n-----END
         PGP PUBLIC KEY BLOCK-----\\n\", \n        \"type\": \"PGP\"\n      }, \n      \"last_updated\":
-        \"2018-10-22T22:48:15.508121Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
-        2, \n      \"remove_star_url\": \"/api/v1/sources/f1ed565f-ed3f-4316-9de8-56dd8af3b4a4/remove_star\",
-        \n      \"replies_url\": \"/api/v1/sources/f1ed565f-ed3f-4316-9de8-56dd8af3b4a4/replies\",
-        \n      \"submissions_url\": \"/api/v1/sources/f1ed565f-ed3f-4316-9de8-56dd8af3b4a4/submissions\",
-        \n      \"url\": \"/api/v1/sources/f1ed565f-ed3f-4316-9de8-56dd8af3b4a4\",
-        \n      \"uuid\": \"f1ed565f-ed3f-4316-9de8-56dd8af3b4a4\"\n    }, \n    {\n
-        \     \"add_star_url\": \"/api/v1/sources/eb01cec4-7216-4112-b542-fcc9c3979b90/add_star\",
+        \"2019-03-18T22:23:44.186714Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
+        2, \n      \"remove_star_url\": \"/api/v1/sources/d9eb4d27-b7c8-4599-ba22-daee6d939f17/remove_star\",
+        \n      \"replies_url\": \"/api/v1/sources/d9eb4d27-b7c8-4599-ba22-daee6d939f17/replies\",
+        \n      \"submissions_url\": \"/api/v1/sources/d9eb4d27-b7c8-4599-ba22-daee6d939f17/submissions\",
+        \n      \"url\": \"/api/v1/sources/d9eb4d27-b7c8-4599-ba22-daee6d939f17\",
+        \n      \"uuid\": \"d9eb4d27-b7c8-4599-ba22-daee6d939f17\"\n    }, \n    {\n
+        \     \"add_star_url\": \"/api/v1/sources/8b8325d9-20a5-4687-8bdf-f0d45408ca38/add_star\",
         \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
-        false, \n      \"journalist_designation\": \"downstairs depth\", \n      \"key\":
-        {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFvOU7ABEADagsl6IqF46/B502qxTKB2OS6FsqQT3BOyseZpALgvrs7tBmsU\\n9qZrEZ5mEVKQK0wA/4Axt+J0rwNieC3egz/hSfJrxdedIEeX6GYJpN9C2tGj2X1Q\\nn9OCPT7GtgVuwUX+2WUyVsmcikF0gQL+VgFAW3TRAT1qWZ2TROYloQGvZZNJM7cx\\n/UKZDOBxyuuhgn1OqSXQF9W/tzZB+7TfN1xdxMDlfr4JVMuh8H2dK+KLdfcaw3BK\\ndOEw8XWTkqDK9E7ZHbzQImOqWJG0TMvo1k02zuPiA2E4JQHg7+mnL8rrRjZ92k+3\\ndsfWoNhKqlcy8Yd9uxb4OY3uo4u+VF6fShTpbYngYmFImg/54C1rge0UpZX0uc1f\\ndYJP6GH41NC/+kaUROTq66tVsKZM+jewIs+FvgvUmLF0jH2Tv/o2K0urw8LNiY9W\\nc+3zkNAq+K/Q+QjhLF7fFXUf7JVT7z3pyjuphrLmUT+yyJvFGOjAOau0YKygCoiG\\nHWmneB1SFoY2d5CnyWW1tfaG2TcN8Beiv1tOLayvLmweVCyyrziidOjwRx3yKDdd\\nD0XyJ2ducIfN4z04OVb14Bfbq4D9s1MpZ4P+jRQcEx+F6xS+Zm/UWOrZgGElCDMs\\nKzVGy4G090xGGKdyqt3d+yEMVHoI1TbWnHdIMzALL4SpIBL36aPouWa56QARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8SENCQ040SVpVTjY0RkEyNTNCTlVLTkMzNUFE\\nRk5DQlgzRkhJSjVIRElSQk1DUEdDSTZSQk03T1M0VUgyV1NUQzI1WkVaU1JOWFkz\\nU1VZV1ZNN1ZTWUhMNEJPTjNNWUhDTVg2RzVUQT0+iQI/BBMBCgApBQJbzlOwAhsv\\nBQkB4JuQBwsJCAcDAgEGFQgCCQoLBBYCAwECHgECF4AACgkQJa7v8Llgs7oVBA/9\\nHZMYvqlcRBca1UHTF8TVR3DhB97TN34smOvGNlh8OJEoPQ+4GKIcbToJ1cgWSf6Q\\nHECs/++DJYSlEj1fRi3xPDxMOKerkzCU6Hm0g1FzX7O/v/p0OpTGgLC3PSFMTZ26\\neP+1r5EfdEr4f0yvT7LhiUOWpPJSlobgQtb0up75eVjJeuSlYd2l2DYi8Lo6K+pX\\ndq1g532s/Elc7GpJfvanfR8lz5NVerAe1oYccjWF4iukiID1MsdVS0LMk4zRklND\\nolOoHOY+Set6jdvbC2y8bDr/o92wgBiTVL1tBqY66xIDN/F+sxFtF7slg9hMrIN8\\nIlhCEURDm/H6HeJn4hqGSCfbCL2DwZb1/X5eYc0w1y69tyzCgiGVUdwMu34LfurU\\nxQeX+CLXhNrbi4iVUJkH8L3NRhSIiemfss032oswXWzidwDjv9iwAYC6dbYy/4al\\n39Prp9chEt23bWJ20F/t7nsyDyGO3u1Y2wFUXev5FZ0seNAuDRkjwSltgvAumB+x\\noB7n6MeN8wHckbVMLYkwKxg2PT+V7mj8zVdwTMfmfV7opoDRxHtvLzCJAveUOhnR\\n6iwt4dtDm08FjBoot1bVz15jqtR+MLbdoYGMFnuBOXJ7jym0mmQjLb3kGpbEwD03\\ndUPFTKGdN/KLrYD005pi8cBIFKznKKs/WZkSQGnUG7Q=\\n=AoO+\\n-----END
+        false, \n      \"journalist_designation\": \"untrammeled dancing\", \n      \"key\":
+        {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFGRfoABEADzzNyczWaTEHPlB0YCa6Kxu4tXmXl7VOXdfCPb7G6XkjWGBSKN\\nQqPJ0rsfilX00vRLf2xxf4036zZ0CO358405eDmN/BNBtLahP8EJBTDi40NebdXf\\nxNE0gaos/MkMIL9fL2SJHcUvJZj7+YfBe+9FatRf1M7+m4Zh4KfRK3xaF0VYGRuo\\nGZ551+16D7243TaM+KNy1oEy3kYXxU32/pdqrxJ4jAGy4J6l++M47o5i0drNbQ4D\\nVNQgYihhCLWGdMAIcF8ORg8j3s196Xv9tQSl89eofw22ccAfqoHCVdcbvcZQ0YKU\\noVXrUoALdueS4imyksmOaKjhJANCxs7ChEnHRNcpGN0XbGITwT6rjLeNCYAVdYVM\\nb4fqM2wHA/y+g3hElrBiBHXvc0hp8S9162CQPSJj60hIe0dJw1dkrAZUFMLA0nvm\\n8SWCnE+2r8J52pI515CY5G6ndnwtrruIigoDazKfIWU/SQWi+eDR0QGzsNzOTJ5L\\n5T4EEO3cXj9DIdBHwaYJ1CvNyxI1mfP2yiDi6Jpb1dVfExh1/yhrZyCkEQfbEAFG\\npvUSIBlh/n6ZDGiUDFmH8wOoNMC0C3Q7N458Y/L8VhliCisANhh2R0SXiY+gAUK2\\nisN3N/+/ed5sglP4HCFn2hgog1vAO1FV3PMWOfiE+8sVixi7xVhatJqw5QARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8WURLRk4zQUtWVUJIWURSVVlCTkFZVEVZNjdB\\nRTdaRkJXTVRCS0ZMU1BSQjJLUTVUVU9IVTVITlkzUDZVUk1LVlRPWEVVUlFVWFlS\\nRklCUVhUS1JJMlJVRU1BRjdVUzdHNE5WWjRWUT0+iQI3BBMBCgAhBQJRkX6AAhsv\\nBQsJCAcCBhUICQoLAgQWAgMBAh4BAheAAAoJEHKp8dqMthpjUyoP/2wgVwZYK7Cr\\nM+RP6jrEyV3WV/LqE9hUp5r5pTI6qAslp3APLCBp6Q1BuNWEsx4b/GFhkPrhwZpS\\nJkngPmxw7JHo0aK0SX9+/jBTwb2+orDIHcs+IiDpyRjkpKi8KV87cfvGLvaTE+Jc\\niopTsafJ9O9IE5WpVlwyA7CxESe+2M7cLWknbpImcytlcxPot61a87oIdWk/BZv1\\nwDpsfO/Tv3q5YFbNaGn5kPvUGaVbxhRODqaNcxE/24AxgtrimPpbaf3s5zWERf5k\\nTC6PUq2z3qEmtuKUkj8skBv5DFkaAeq7Ulx4PPkaeguLvQOIhRHDie3pX9cuak2B\\nb/7lFs4FKpMGE4XSkOqXJY4q/kkKlEk7x9sTqI29tkOVbhYaUBw6vDT+O/zLxjg1\\nvKPXFO7ylegdAECUSIJnzDqyN9v+hVOXxt726EYYfMQqIo384zZOp/JOngNWKNfr\\nT2VhBnANjeLCqLcN3ofwJK8jY9fidqqpidZ50IX5lEI2s3/QaouldLhlAKqKH0e5\\nCgmg2F68MJN1o/LbYPCt5hE8xCI9i3Q//MefQKG3GspFRdS3BiXyoLwTf7HrGOoC\\nXzC7byFTxOMYPYj/EYTQd8I6NByvjGbRYMZrv6Dy6NAqZobq9QdrR/F7kYiTLRF/\\ncd3FLzg6d15rMyHMeEQQCj/8Bzrbx0QV\\n=e2OF\\n-----END
         PGP PUBLIC KEY BLOCK-----\\n\", \n        \"type\": \"PGP\"\n      }, \n      \"last_updated\":
-        \"2018-10-22T22:48:17.821470Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
-        2, \n      \"remove_star_url\": \"/api/v1/sources/eb01cec4-7216-4112-b542-fcc9c3979b90/remove_star\",
-        \n      \"replies_url\": \"/api/v1/sources/eb01cec4-7216-4112-b542-fcc9c3979b90/replies\",
-        \n      \"submissions_url\": \"/api/v1/sources/eb01cec4-7216-4112-b542-fcc9c3979b90/submissions\",
-        \n      \"url\": \"/api/v1/sources/eb01cec4-7216-4112-b542-fcc9c3979b90\",
-        \n      \"uuid\": \"eb01cec4-7216-4112-b542-fcc9c3979b90\"\n    }\n  ]\n}\n"}
+        \"2019-03-18T22:23:46.635201Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
+        2, \n      \"remove_star_url\": \"/api/v1/sources/8b8325d9-20a5-4687-8bdf-f0d45408ca38/remove_star\",
+        \n      \"replies_url\": \"/api/v1/sources/8b8325d9-20a5-4687-8bdf-f0d45408ca38/replies\",
+        \n      \"submissions_url\": \"/api/v1/sources/8b8325d9-20a5-4687-8bdf-f0d45408ca38/submissions\",
+        \n      \"url\": \"/api/v1/sources/8b8325d9-20a5-4687-8bdf-f0d45408ca38\",
+        \n      \"uuid\": \"8b8325d9-20a5-4687-8bdf-f0d45408ca38\"\n    }\n  ]\n}\n"}
     headers:
-      Content-Length: ['5244']
+      Content-Length: ['5210']
       Content-Type: [application/json]
-      Date: ['Mon, 22 Oct 2018 22:48:28 GMT']
-      Server: [Werkzeug/0.14.1 Python/2.7.6]
-      Set-Cookie: [js=eyJleHBpcmVzIjp7IiBkIjoiVHVlLCAyMyBPY3QgMjAxOCAwMDo0ODoyOCBHTVQifX0.Dq_lPA.xCBt3s1su7-BcVhsHXG7gP-oQD0;
-          HttpOnly; Path=/]
-      Vary: [Cookie]
+      Date: ['Mon, 18 Mar 2019 23:18:51 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU0MDI3NjkxOCwiaWF0IjoxNTQwMjQ4MTE4fQ.eyJpZCI6MX0.fygpQy3CxB1ulUWLFz2UdrtcBKHz-fk5gyRxbcSY720]
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1Mjk3OTkzMSwiaWF0IjoxNTUyOTUxMTMxfQ.eyJpZCI6MX0.9P3wxI-3_VKsD2YC5HZ31pfWuqLEBJsy9aBhW_cdqXE]
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: http://127.0.0.1:8081/api/v1/sources
+  response:
+    body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/d9eb4d27-b7c8-4599-ba22-daee6d939f17/add_star\",
+        \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
+        false, \n      \"journalist_designation\": \"raging azure\", \n      \"key\":
+        {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFGRfoABEADEQMD9oHNCk7gvgk6/W2kx+DkaoM1I24fDlx3soKXqmRjyK1MK\\nx/ecx6ta3I1KRIwl6Iy1QCEhGjmR3PNEY61n6n2Jv8n2NtDx31Gagp1f8ckhPtYq\\n2BP9VzxkTIqbwi6oOaKl3GCarkZD1/detSH8Sdzk9uzlE49Qn/wCsFyW69GtJBFT\\nVZ0F5hPJItXOAT1mHrRc1Hl/lsmax61rqLGuvuCxnpe3UrDKtfxL2uNKzGYm687P\\nAxVBbHE7HlOLJ8YAVlIJQzcWXHvj5yBE2U6ANYrUYqLsuOImA5Ruwb/UwhKP+zQ5\\nhGOgizEmE3NvH5Hmex2ir+Bl3FKSn8QgvbOwXhSxkNcn+YREB8exNxZJ2SH80JvQ\\ndYR0Onfcr9W2Qn4xdvpaaR1i1faGJ9Mc2O1bg/lubpJKNh0KJsqX5yZMWFbA5nQJ\\nAO7/3tU1a9BSISEc5ICeAD+DSHYc+vsDoBcN8Fmh/p0fzDAM6AXfpl5vggzhPXTN\\ncJlJGVBTPZh4SLDLmL1lvEytoLBErzjF+rYpLDrQurflN3bGdWEKoQZxwc1I5f/h\\n/v3ZkHFwIcOV1TwVfRvmYP2Q3H+86pHeFFStb1mCh0EuS+ygwMkPIirQnIpDa3iB\\nNRLTZvdQW0T8XswQWisGL/R+mKUX1HkMkqYp/lPAqmFuNtzgWcg4pTeOmQARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8M0hBT0VaUzVVSkZUQ0tOU0FGNjRHSDJaT082\\nN0NCSUhGWkxXTEdaTTI2MzYzQ1BEQ1ZERUtBSEdIWU1HVlFJTk5OUVVDQVRHREJQ\\nRFNJRlYyUEoyWFE2UFpZWllSN09VNkROWUFXST0+iQI3BBMBCgAhBQJRkX6AAhsv\\nBQsJCAcCBhUICQoLAgQWAgMBAh4BAheAAAoJEL+uIhVjsHuRvuMP/16AhT5kbRJQ\\n109ZhDfH7pOl4avUutY7OYPHDEgFR+6BwStKZcmP/1Amx+2eUcRno8dAlSbTKYFI\\nq1gss9e/xwz1xK7qtUDFxfZL2dbNq877kmCEjNY63kLkme6O6ltCxNJ+TINKK2ff\\nkOanD3t58xILFV4nxzZd2GRWy1IEYJb3OCZ9UD0alCAZcV2RHJjJoMCRqTSfW7rV\\njrZlQZEQHIocDBlYLM461ZyP/TnCwfc/quz0GoJR+qVU+hY5sYrUh1M62cT+bKxd\\nL5Rnk/4DIx89QvcQKR0l330iB9Pu16+Ks7DaOU85M17Smg7Pjc9nYsUwgS6vQQmV\\nU6Rjlfqa7JglA54cWPd9WkRlT+cUlCUlctowgpTiAA0uzc3bu6YQ7RefGU5qnLIH\\ndDtAzIDTCeJdaJZvd2MaV0KICe4mU2RpJYlDSVUfzVb/xK6vVN6maN5tnJ6dpirj\\nA6WhGl+aKA4Ou6ok1mOHLEfAcCEbUrR8FF1MPZ9/DWRYpQpJhAfBG3pSfUByf5/w\\nt3WVNpiXWet/DXwFLsUpra7sNAb5+BFaEv22Y2bFF0TEkai39PdKUnVzc7jjSRvZ\\n84cfRurWK9GR8ynSLEmu47/beWzRIO5qBe3VIdDUL2w0PhH/rKiGg5zBDy8b8otz\\n2OCPH1/t36o/CP6SrIJdE1l1Z6RoS0C/\\n=DXES\\n-----END
+        PGP PUBLIC KEY BLOCK-----\\n\", \n        \"type\": \"PGP\"\n      }, \n      \"last_updated\":
+        \"2019-03-18T22:23:44.186714Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
+        2, \n      \"remove_star_url\": \"/api/v1/sources/d9eb4d27-b7c8-4599-ba22-daee6d939f17/remove_star\",
+        \n      \"replies_url\": \"/api/v1/sources/d9eb4d27-b7c8-4599-ba22-daee6d939f17/replies\",
+        \n      \"submissions_url\": \"/api/v1/sources/d9eb4d27-b7c8-4599-ba22-daee6d939f17/submissions\",
+        \n      \"url\": \"/api/v1/sources/d9eb4d27-b7c8-4599-ba22-daee6d939f17\",
+        \n      \"uuid\": \"d9eb4d27-b7c8-4599-ba22-daee6d939f17\"\n    }, \n    {\n
+        \     \"add_star_url\": \"/api/v1/sources/8b8325d9-20a5-4687-8bdf-f0d45408ca38/add_star\",
+        \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
+        false, \n      \"journalist_designation\": \"untrammeled dancing\", \n      \"key\":
+        {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFGRfoABEADzzNyczWaTEHPlB0YCa6Kxu4tXmXl7VOXdfCPb7G6XkjWGBSKN\\nQqPJ0rsfilX00vRLf2xxf4036zZ0CO358405eDmN/BNBtLahP8EJBTDi40NebdXf\\nxNE0gaos/MkMIL9fL2SJHcUvJZj7+YfBe+9FatRf1M7+m4Zh4KfRK3xaF0VYGRuo\\nGZ551+16D7243TaM+KNy1oEy3kYXxU32/pdqrxJ4jAGy4J6l++M47o5i0drNbQ4D\\nVNQgYihhCLWGdMAIcF8ORg8j3s196Xv9tQSl89eofw22ccAfqoHCVdcbvcZQ0YKU\\noVXrUoALdueS4imyksmOaKjhJANCxs7ChEnHRNcpGN0XbGITwT6rjLeNCYAVdYVM\\nb4fqM2wHA/y+g3hElrBiBHXvc0hp8S9162CQPSJj60hIe0dJw1dkrAZUFMLA0nvm\\n8SWCnE+2r8J52pI515CY5G6ndnwtrruIigoDazKfIWU/SQWi+eDR0QGzsNzOTJ5L\\n5T4EEO3cXj9DIdBHwaYJ1CvNyxI1mfP2yiDi6Jpb1dVfExh1/yhrZyCkEQfbEAFG\\npvUSIBlh/n6ZDGiUDFmH8wOoNMC0C3Q7N458Y/L8VhliCisANhh2R0SXiY+gAUK2\\nisN3N/+/ed5sglP4HCFn2hgog1vAO1FV3PMWOfiE+8sVixi7xVhatJqw5QARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8WURLRk4zQUtWVUJIWURSVVlCTkFZVEVZNjdB\\nRTdaRkJXTVRCS0ZMU1BSQjJLUTVUVU9IVTVITlkzUDZVUk1LVlRPWEVVUlFVWFlS\\nRklCUVhUS1JJMlJVRU1BRjdVUzdHNE5WWjRWUT0+iQI3BBMBCgAhBQJRkX6AAhsv\\nBQsJCAcCBhUICQoLAgQWAgMBAh4BAheAAAoJEHKp8dqMthpjUyoP/2wgVwZYK7Cr\\nM+RP6jrEyV3WV/LqE9hUp5r5pTI6qAslp3APLCBp6Q1BuNWEsx4b/GFhkPrhwZpS\\nJkngPmxw7JHo0aK0SX9+/jBTwb2+orDIHcs+IiDpyRjkpKi8KV87cfvGLvaTE+Jc\\niopTsafJ9O9IE5WpVlwyA7CxESe+2M7cLWknbpImcytlcxPot61a87oIdWk/BZv1\\nwDpsfO/Tv3q5YFbNaGn5kPvUGaVbxhRODqaNcxE/24AxgtrimPpbaf3s5zWERf5k\\nTC6PUq2z3qEmtuKUkj8skBv5DFkaAeq7Ulx4PPkaeguLvQOIhRHDie3pX9cuak2B\\nb/7lFs4FKpMGE4XSkOqXJY4q/kkKlEk7x9sTqI29tkOVbhYaUBw6vDT+O/zLxjg1\\nvKPXFO7ylegdAECUSIJnzDqyN9v+hVOXxt726EYYfMQqIo384zZOp/JOngNWKNfr\\nT2VhBnANjeLCqLcN3ofwJK8jY9fidqqpidZ50IX5lEI2s3/QaouldLhlAKqKH0e5\\nCgmg2F68MJN1o/LbYPCt5hE8xCI9i3Q//MefQKG3GspFRdS3BiXyoLwTf7HrGOoC\\nXzC7byFTxOMYPYj/EYTQd8I6NByvjGbRYMZrv6Dy6NAqZobq9QdrR/F7kYiTLRF/\\ncd3FLzg6d15rMyHMeEQQCj/8Bzrbx0QV\\n=e2OF\\n-----END
+        PGP PUBLIC KEY BLOCK-----\\n\", \n        \"type\": \"PGP\"\n      }, \n      \"last_updated\":
+        \"2019-03-18T22:23:46.635201Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
+        2, \n      \"remove_star_url\": \"/api/v1/sources/8b8325d9-20a5-4687-8bdf-f0d45408ca38/remove_star\",
+        \n      \"replies_url\": \"/api/v1/sources/8b8325d9-20a5-4687-8bdf-f0d45408ca38/replies\",
+        \n      \"submissions_url\": \"/api/v1/sources/8b8325d9-20a5-4687-8bdf-f0d45408ca38/submissions\",
+        \n      \"url\": \"/api/v1/sources/8b8325d9-20a5-4687-8bdf-f0d45408ca38\",
+        \n      \"uuid\": \"8b8325d9-20a5-4687-8bdf-f0d45408ca38\"\n    }\n  ]\n}\n"}
+    headers:
+      Content-Length: ['5210']
+      Content-Type: [application/json]
+      Date: ['Mon, 18 Mar 2019 23:18:51 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1Mjk3OTkzMSwiaWF0IjoxNTUyOTUxMTMxfQ.eyJpZCI6MX0.9P3wxI-3_VKsD2YC5HZ31pfWuqLEBJsy9aBhW_cdqXE]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: DELETE
-    uri: http://127.0.0.1:8081/api/v1/sources/f1ed565f-ed3f-4316-9de8-56dd8af3b4a4
+    uri: http://127.0.0.1:8081/api/v1/sources/d9eb4d27-b7c8-4599-ba22-daee6d939f17
   response:
     body: {string: "{\n  \"message\": \"Source and submissions deleted\"\n}\n"}
     headers:
       Content-Length: ['50']
       Content-Type: [application/json]
-      Date: ['Mon, 22 Oct 2018 22:48:28 GMT']
-      Server: [Werkzeug/0.14.1 Python/2.7.6]
-      Set-Cookie: [js=eyJleHBpcmVzIjp7IiBkIjoiVHVlLCAyMyBPY3QgMjAxOCAwMDo0ODoyOCBHTVQifX0.Dq_lPA.xCBt3s1su7-BcVhsHXG7gP-oQD0;
-          HttpOnly; Path=/]
-      Vary: [Cookie]
+      Date: ['Mon, 18 Mar 2019 23:18:51 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU0MDI3NjkxOCwiaWF0IjoxNTQwMjQ4MTE4fQ.eyJpZCI6MX0.fygpQy3CxB1ulUWLFz2UdrtcBKHz-fk5gyRxbcSY720]
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1Mjk3OTkzMSwiaWF0IjoxNTUyOTUxMTMxfQ.eyJpZCI6MX0.9P3wxI-3_VKsD2YC5HZ31pfWuqLEBJsy9aBhW_cdqXE]
       Connection: [keep-alive]
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
     uri: http://127.0.0.1:8081/api/v1/sources
   response:
-    body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/eb01cec4-7216-4112-b542-fcc9c3979b90/add_star\",
+    body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/8b8325d9-20a5-4687-8bdf-f0d45408ca38/add_star\",
         \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
-        false, \n      \"journalist_designation\": \"downstairs depth\", \n      \"key\":
-        {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFvOU7ABEADagsl6IqF46/B502qxTKB2OS6FsqQT3BOyseZpALgvrs7tBmsU\\n9qZrEZ5mEVKQK0wA/4Axt+J0rwNieC3egz/hSfJrxdedIEeX6GYJpN9C2tGj2X1Q\\nn9OCPT7GtgVuwUX+2WUyVsmcikF0gQL+VgFAW3TRAT1qWZ2TROYloQGvZZNJM7cx\\n/UKZDOBxyuuhgn1OqSXQF9W/tzZB+7TfN1xdxMDlfr4JVMuh8H2dK+KLdfcaw3BK\\ndOEw8XWTkqDK9E7ZHbzQImOqWJG0TMvo1k02zuPiA2E4JQHg7+mnL8rrRjZ92k+3\\ndsfWoNhKqlcy8Yd9uxb4OY3uo4u+VF6fShTpbYngYmFImg/54C1rge0UpZX0uc1f\\ndYJP6GH41NC/+kaUROTq66tVsKZM+jewIs+FvgvUmLF0jH2Tv/o2K0urw8LNiY9W\\nc+3zkNAq+K/Q+QjhLF7fFXUf7JVT7z3pyjuphrLmUT+yyJvFGOjAOau0YKygCoiG\\nHWmneB1SFoY2d5CnyWW1tfaG2TcN8Beiv1tOLayvLmweVCyyrziidOjwRx3yKDdd\\nD0XyJ2ducIfN4z04OVb14Bfbq4D9s1MpZ4P+jRQcEx+F6xS+Zm/UWOrZgGElCDMs\\nKzVGy4G090xGGKdyqt3d+yEMVHoI1TbWnHdIMzALL4SpIBL36aPouWa56QARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8SENCQ040SVpVTjY0RkEyNTNCTlVLTkMzNUFE\\nRk5DQlgzRkhJSjVIRElSQk1DUEdDSTZSQk03T1M0VUgyV1NUQzI1WkVaU1JOWFkz\\nU1VZV1ZNN1ZTWUhMNEJPTjNNWUhDTVg2RzVUQT0+iQI/BBMBCgApBQJbzlOwAhsv\\nBQkB4JuQBwsJCAcDAgEGFQgCCQoLBBYCAwECHgECF4AACgkQJa7v8Llgs7oVBA/9\\nHZMYvqlcRBca1UHTF8TVR3DhB97TN34smOvGNlh8OJEoPQ+4GKIcbToJ1cgWSf6Q\\nHECs/++DJYSlEj1fRi3xPDxMOKerkzCU6Hm0g1FzX7O/v/p0OpTGgLC3PSFMTZ26\\neP+1r5EfdEr4f0yvT7LhiUOWpPJSlobgQtb0up75eVjJeuSlYd2l2DYi8Lo6K+pX\\ndq1g532s/Elc7GpJfvanfR8lz5NVerAe1oYccjWF4iukiID1MsdVS0LMk4zRklND\\nolOoHOY+Set6jdvbC2y8bDr/o92wgBiTVL1tBqY66xIDN/F+sxFtF7slg9hMrIN8\\nIlhCEURDm/H6HeJn4hqGSCfbCL2DwZb1/X5eYc0w1y69tyzCgiGVUdwMu34LfurU\\nxQeX+CLXhNrbi4iVUJkH8L3NRhSIiemfss032oswXWzidwDjv9iwAYC6dbYy/4al\\n39Prp9chEt23bWJ20F/t7nsyDyGO3u1Y2wFUXev5FZ0seNAuDRkjwSltgvAumB+x\\noB7n6MeN8wHckbVMLYkwKxg2PT+V7mj8zVdwTMfmfV7opoDRxHtvLzCJAveUOhnR\\n6iwt4dtDm08FjBoot1bVz15jqtR+MLbdoYGMFnuBOXJ7jym0mmQjLb3kGpbEwD03\\ndUPFTKGdN/KLrYD005pi8cBIFKznKKs/WZkSQGnUG7Q=\\n=AoO+\\n-----END
+        false, \n      \"journalist_designation\": \"untrammeled dancing\", \n      \"key\":
+        {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFGRfoABEADzzNyczWaTEHPlB0YCa6Kxu4tXmXl7VOXdfCPb7G6XkjWGBSKN\\nQqPJ0rsfilX00vRLf2xxf4036zZ0CO358405eDmN/BNBtLahP8EJBTDi40NebdXf\\nxNE0gaos/MkMIL9fL2SJHcUvJZj7+YfBe+9FatRf1M7+m4Zh4KfRK3xaF0VYGRuo\\nGZ551+16D7243TaM+KNy1oEy3kYXxU32/pdqrxJ4jAGy4J6l++M47o5i0drNbQ4D\\nVNQgYihhCLWGdMAIcF8ORg8j3s196Xv9tQSl89eofw22ccAfqoHCVdcbvcZQ0YKU\\noVXrUoALdueS4imyksmOaKjhJANCxs7ChEnHRNcpGN0XbGITwT6rjLeNCYAVdYVM\\nb4fqM2wHA/y+g3hElrBiBHXvc0hp8S9162CQPSJj60hIe0dJw1dkrAZUFMLA0nvm\\n8SWCnE+2r8J52pI515CY5G6ndnwtrruIigoDazKfIWU/SQWi+eDR0QGzsNzOTJ5L\\n5T4EEO3cXj9DIdBHwaYJ1CvNyxI1mfP2yiDi6Jpb1dVfExh1/yhrZyCkEQfbEAFG\\npvUSIBlh/n6ZDGiUDFmH8wOoNMC0C3Q7N458Y/L8VhliCisANhh2R0SXiY+gAUK2\\nisN3N/+/ed5sglP4HCFn2hgog1vAO1FV3PMWOfiE+8sVixi7xVhatJqw5QARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8WURLRk4zQUtWVUJIWURSVVlCTkFZVEVZNjdB\\nRTdaRkJXTVRCS0ZMU1BSQjJLUTVUVU9IVTVITlkzUDZVUk1LVlRPWEVVUlFVWFlS\\nRklCUVhUS1JJMlJVRU1BRjdVUzdHNE5WWjRWUT0+iQI3BBMBCgAhBQJRkX6AAhsv\\nBQsJCAcCBhUICQoLAgQWAgMBAh4BAheAAAoJEHKp8dqMthpjUyoP/2wgVwZYK7Cr\\nM+RP6jrEyV3WV/LqE9hUp5r5pTI6qAslp3APLCBp6Q1BuNWEsx4b/GFhkPrhwZpS\\nJkngPmxw7JHo0aK0SX9+/jBTwb2+orDIHcs+IiDpyRjkpKi8KV87cfvGLvaTE+Jc\\niopTsafJ9O9IE5WpVlwyA7CxESe+2M7cLWknbpImcytlcxPot61a87oIdWk/BZv1\\nwDpsfO/Tv3q5YFbNaGn5kPvUGaVbxhRODqaNcxE/24AxgtrimPpbaf3s5zWERf5k\\nTC6PUq2z3qEmtuKUkj8skBv5DFkaAeq7Ulx4PPkaeguLvQOIhRHDie3pX9cuak2B\\nb/7lFs4FKpMGE4XSkOqXJY4q/kkKlEk7x9sTqI29tkOVbhYaUBw6vDT+O/zLxjg1\\nvKPXFO7ylegdAECUSIJnzDqyN9v+hVOXxt726EYYfMQqIo384zZOp/JOngNWKNfr\\nT2VhBnANjeLCqLcN3ofwJK8jY9fidqqpidZ50IX5lEI2s3/QaouldLhlAKqKH0e5\\nCgmg2F68MJN1o/LbYPCt5hE8xCI9i3Q//MefQKG3GspFRdS3BiXyoLwTf7HrGOoC\\nXzC7byFTxOMYPYj/EYTQd8I6NByvjGbRYMZrv6Dy6NAqZobq9QdrR/F7kYiTLRF/\\ncd3FLzg6d15rMyHMeEQQCj/8Bzrbx0QV\\n=e2OF\\n-----END
         PGP PUBLIC KEY BLOCK-----\\n\", \n        \"type\": \"PGP\"\n      }, \n      \"last_updated\":
-        \"2018-10-22T22:48:17.821470Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
-        2, \n      \"remove_star_url\": \"/api/v1/sources/eb01cec4-7216-4112-b542-fcc9c3979b90/remove_star\",
-        \n      \"replies_url\": \"/api/v1/sources/eb01cec4-7216-4112-b542-fcc9c3979b90/replies\",
-        \n      \"submissions_url\": \"/api/v1/sources/eb01cec4-7216-4112-b542-fcc9c3979b90/submissions\",
-        \n      \"url\": \"/api/v1/sources/eb01cec4-7216-4112-b542-fcc9c3979b90\",
-        \n      \"uuid\": \"eb01cec4-7216-4112-b542-fcc9c3979b90\"\n    }\n  ]\n}\n"}
+        \"2019-03-18T22:23:46.635201Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
+        2, \n      \"remove_star_url\": \"/api/v1/sources/8b8325d9-20a5-4687-8bdf-f0d45408ca38/remove_star\",
+        \n      \"replies_url\": \"/api/v1/sources/8b8325d9-20a5-4687-8bdf-f0d45408ca38/replies\",
+        \n      \"submissions_url\": \"/api/v1/sources/8b8325d9-20a5-4687-8bdf-f0d45408ca38/submissions\",
+        \n      \"url\": \"/api/v1/sources/8b8325d9-20a5-4687-8bdf-f0d45408ca38\",
+        \n      \"uuid\": \"8b8325d9-20a5-4687-8bdf-f0d45408ca38\"\n    }\n  ]\n}\n"}
     headers:
-      Content-Length: ['2628']
+      Content-Length: ['2619']
       Content-Type: [application/json]
-      Date: ['Mon, 22 Oct 2018 22:48:28 GMT']
-      Server: [Werkzeug/0.14.1 Python/2.7.6]
-      Set-Cookie: [js=eyJleHBpcmVzIjp7IiBkIjoiVHVlLCAyMyBPY3QgMjAxOCAwMDo0ODoyOCBHTVQifX0.Dq_lPA.xCBt3s1su7-BcVhsHXG7gP-oQD0;
-          HttpOnly; Path=/]
-      Vary: [Cookie]
+      Date: ['Mon, 18 Mar 2019 23:18:51 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
     status: {code: 200, message: OK}
 version: 1

--- a/data/test-delete-source.yml
+++ b/data/test-delete-source.yml
@@ -9,7 +9,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources
+    uri: http://127.0.0.1:8081/api/v1/sources
   response:
     body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/f1ed565f-ed3f-4316-9de8-56dd8af3b4a4/add_star\",
         \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
@@ -53,7 +53,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: DELETE
-    uri: http://localhost:8081/api/v1/sources/f1ed565f-ed3f-4316-9de8-56dd8af3b4a4
+    uri: http://127.0.0.1:8081/api/v1/sources/f1ed565f-ed3f-4316-9de8-56dd8af3b4a4
   response:
     body: {string: "{\n  \"message\": \"Source and submissions deleted\"\n}\n"}
     headers:
@@ -75,7 +75,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources
+    uri: http://127.0.0.1:8081/api/v1/sources
   response:
     body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/eb01cec4-7216-4112-b542-fcc9c3979b90/add_star\",
         \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":

--- a/data/test-delete-submission-from-string.yml
+++ b/data/test-delete-submission-from-string.yml
@@ -9,7 +9,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources
+    uri: http://127.0.0.1:8081/api/v1/sources
   response:
     body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/83442bde-13e7-49a7-b162-646e7f8f87f4/add_star\",
         \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
@@ -52,7 +52,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources/83442bde-13e7-49a7-b162-646e7f8f87f4/submissions
+    uri: http://127.0.0.1:8081/api/v1/sources/83442bde-13e7-49a7-b162-646e7f8f87f4/submissions
   response:
     body: {string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/83442bde-13e7-49a7-b162-646e7f8f87f4/submissions/5b157795-1f3f-47ad-96ce-a8b6fe69f6e3/download\",
         \n      \"filename\": \"1-divided_sawdust-msg.gpg\", \n      \"is_read\":
@@ -84,7 +84,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: DELETE
-    uri: http://localhost:8081/api/v1/sources/83442bde-13e7-49a7-b162-646e7f8f87f4/submissions/5b157795-1f3f-47ad-96ce-a8b6fe69f6e3
+    uri: http://127.0.0.1:8081/api/v1/sources/83442bde-13e7-49a7-b162-646e7f8f87f4/submissions/5b157795-1f3f-47ad-96ce-a8b6fe69f6e3
   response:
     body: {string: "{\n  \"message\": \"Submission deleted\"\n}\n"}
     headers:
@@ -106,7 +106,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/submissions
+    uri: http://127.0.0.1:8081/api/v1/submissions
   response:
     body: {string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/83442bde-13e7-49a7-b162-646e7f8f87f4/submissions/50207602-863b-41cd-8451-2af42e45ece8/download\",
         \n      \"filename\": \"2-divided_sawdust-msg.gpg\", \n      \"is_read\":

--- a/data/test-delete-submission-from-string.yml
+++ b/data/test-delete-submission-from-string.yml
@@ -4,132 +4,143 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU0MDI3NjkxOCwiaWF0IjoxNTQwMjQ4MTE4fQ.eyJpZCI6MX0.fygpQy3CxB1ulUWLFz2UdrtcBKHz-fk5gyRxbcSY720]
-      Connection: [keep-alive]
-      Content-Type: [application/json]
-      User-Agent: [python-requests/2.20.0]
-    method: GET
-    uri: http://127.0.0.1:8081/api/v1/sources
-  response:
-    body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/83442bde-13e7-49a7-b162-646e7f8f87f4/add_star\",
-        \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
-        false, \n      \"journalist_designation\": \"divided sawdust\", \n      \"key\":
-        {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFvOU/oBEACxBiAEh6pYDlmjdMjEJ9CDGMtnBGZLLHZ5BuHAHUwuIO2iHUGj\\nc6jdlUDdp/NUuV7pGXIEvqMXaKMuds8lJCE/iRQm151NNMKe9eHLwzXPAFJVslGU\\nPgW1aYcCrg3p7Wb71R+kGdHiUcENU7isMuVCp9hMkZnsI7nXRI96dkJalIaFS7im\\nFr1BncjXE/5dOEKAQszx8ud+OY6x2zpMOASTHUKXPZq5ShyEGHt4MYMQJxx5zBXE\\nnXa022NHF/JxkRniae7/P1qO1DAHVU7Pk23mRPWcN/7yZfhY0l516sUhlD5+P4/c\\nQdat1Ewlrulvk4v4Ehf3boJ40DyWWzziFjxJRyU6ZIfPdu98kKS1jlmqj/6ku/vL\\nokpWgtaLA3HQxsAXaN5mH9BDbGkpXZMxJbl0vzcWpOyo++4JnpPgDj5CoCjzjxcu\\nFadPaPM5JhbGgr2WUULawanYUkEAnFm/dUQ0TljzdoqBfuZ6nJgTZsLmqQkB9VlH\\nSJmocmXYsOIIR0Epyg74dJdINlA8gbW02J34Rlsq+wJ8Km2vP9aKXAtuYlBP6QVC\\nIKo/zVfuvN7TwwtuXmA21Io1xP7EbUXOQoi+Y6P/6Dv44OZ66OlqpxqwoN63K6S1\\n0I3JG00AU/X1ipudC8G98pL11HKcgTMzrTJlgh+z3O49QUiVyA8c04ihJQARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8SUJWV0dUNFJRV1laN1FPRUhOTjNET09NV0VY\\nTkRaVjVZQ0dSTTdSTkhDSEdLRU1SWDNJVEdGWkpYMk9TNjdOUUw1MjVYUEI1NEVG\\nSkRXQ1ZDQ0tKSkdaWkxDSlJFUkNUR0tFT1dJST0+iQI/BBMBCgApBQJbzlP6Ahsv\\nBQkB4JtGBwsJCAcDAgEGFQgCCQoLBBYCAwECHgECF4AACgkQUohvvi8yjn+iAxAA\\nrLVWY1bUpzb5cLTD/F470jMXsWHcdFwtWHUt556esgN2ZX7RtIkDX7NtMxThJmy6\\nf6RH3OXdNLDzuZMzoO8B9CvxJAxjLPsfeeQr7vDgbyoEjCUdPGAdkhHhKkh20zBV\\nkXD0xBuy6DQoKMGidLXoMC9P7HIByFINV8A+FEkZfIld2VgP54vmrsIzJT6y+Gdi\\n8bfrfsOxxrjXQb/6aWEOUafm3f9EUmBUuuWdH6AsBATQK9QdbECRC9znWmV21A1g\\nizGuDb/YrXZtuakHaGHwtAU4Y5EomMjK+VZaIKtMNok63+0kgey/+VdF3ESNRKUe\\nOPhXZl5SlH5zxy7yv5w1SgSiHRaYGwU9KXJ8WyeuGwNlIgk70sAdl7LvvGDa42ba\\nBFVWoXBSa+b6jWjVkBel9bRDWMlPhVndlFZjYcA6mAZ3CRHeXi68Yz84ULdVgHMv\\n+YY/SDENOIwK8KXQin6+u5xxeQ9u3oh63mcc6BebsF0TUz2k0FQ5uhtuCIBdW1n3\\nINR+jlM2v06jzf4JjfNvIedDzzHo3M40AUrlpV5bE/GHELMcM3RNY8XplLBpdSSB\\nZaAbV3zvwQ1Z82DRXZ5wUjmHcTIwNfVD5lS+NsBtZ/nfMEz2aeX6gIpknDX7U9t0\\n1piF2Y74gdV1e82uurrc4EpCkkar37fKRlLAsxxV1/E=\\n=W9AO\\n-----END
-        PGP PUBLIC KEY BLOCK-----\\n\", \n        \"type\": \"PGP\"\n      }, \n      \"last_updated\":
-        \"2018-10-22T22:49:32.268753Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
-        2, \n      \"remove_star_url\": \"/api/v1/sources/83442bde-13e7-49a7-b162-646e7f8f87f4/remove_star\",
-        \n      \"replies_url\": \"/api/v1/sources/83442bde-13e7-49a7-b162-646e7f8f87f4/replies\",
-        \n      \"submissions_url\": \"/api/v1/sources/83442bde-13e7-49a7-b162-646e7f8f87f4/submissions\",
-        \n      \"url\": \"/api/v1/sources/83442bde-13e7-49a7-b162-646e7f8f87f4\",
-        \n      \"uuid\": \"83442bde-13e7-49a7-b162-646e7f8f87f4\"\n    }, \n    {\n
-        \     \"add_star_url\": \"/api/v1/sources/6ef758d0-c06b-4e8e-9cad-fe97a95037d1/add_star\",
-        \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
-        false, \n      \"journalist_designation\": \"uniform boondoggle\", \n      \"key\":
-        {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFvOU/0BEADa7ktrBGdmCHbEXQAXlZzvesuMA+lAOQN8Ovh5LywKYlHLZ67I\\n7vqdDMxNw/OCiRspJORyxStr4fHRidh6nbdlj0Y8ejFOQK+wbXAX9VztZ/pV8rp/\\n3iM+6JpV/ECeaQztN6g3gUYZYTONUqpmCYXNsp4vCtqBmSgONCf6YkbPAJhrqtXb\\n/gkibdt043o4SkJpOcdIMGqc9TwpIn0f4ryWXSpTZlTArzZ/gO0TEJcN0hZRvOqF\\n1WJAzsvJyL0mmWBd+fvnmXWfGRDuxDdUQN46qHYiUGK6B/VnalXpvmIPCivqwlKV\\nED5Gyw/iCTsOPoOFAdvshv9umlaJXbdapervOLmm7bQu/3EQx9Yrw92V2H2jtOek\\nYIS2WOXhhr6aPYUmwW8AEgv0719Gk8CSGO6XLlMS+aJ055diVZHhjXkxvU3Kauo5\\nP7m6s3FQQcZHpxePkSqDJbf87/O4g7jkFfc7QaY6s/B3WWNeMtSCdN00NKmWrcJw\\nvprdJpqcoOZ9ic6X1cGuErpu09rHq+BSUWa47oQ0lQBtq3Mmq8fOT6Cob1qBHR1Q\\nBrKX95Z5MQW8aRL1+SpobGZYOa2ohfg2IN9mR/4Bs7wkIrjWN+v0Nh8wza9AdRGP\\n7hL+qozUtadCURs3SgIisO6rUO4gCkVY9fDNf48RkAtBRwtTeAyAIN2B2wARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8NjVaNkRBQTdISDNaRlFGTVFMNjdSR04zRDMz\\nRkI2WVFRNkJXNlpMTEY1TENaTjNBTktSS0VJTkpQWlNCUUczSU9MN0EyS05DTVlU\\nVERKRzJBQUZBTUFaTUFDT0dRVUgyN0tRSzRRUT0+iQI/BBMBCgApBQJbzlP9Ahsv\\nBQkB4JtDBwsJCAcDAgEGFQgCCQoLBBYCAwECHgECF4AACgkQc1VGGGgsAaiOdg/8\\nC5DXgkl/e14v7hcl28k+lkC/dNBHbjCmOW+Ew5IAXvjYwf6K6NPyqpq/+L5lrbPL\\naWgVfFexU9CGNfJwr87cjYU+g8AVYq1N7k0YPdq0i7uHZjPHox/GKzXpB1PmlK3D\\nhxIPKqVTTRDzV1yZaxLHJk0mcl5Ow/kbruRMcL4wdiV94a3LxGAuC+Ca73UOOioK\\nxCViP2v+HWXFrHkF5GzWbAKpn3EoEB0bdh8xogamFCvBJ3fprnFnefMGpcgAI3/o\\npGZrjhUE/+hsFe+5KkgBDbEbySY0WcNvEpLBiX7Jall9JzzURu4XTl8QcB0SicYd\\nOPG95BE1C5EBQgZVapHCmx1EASR97WHkynL33JXLdLXZi8Lv+yw30I7uSZQ02A/r\\nSKXmnInD+bJbMMjg/QLHpJ/IUa9gNbhW2h/mVSGIhzwSWq4PQ9E5gXU6PaDYL00v\\ndKhEaOFyF9hEh+8aRjAE/8ztXpTJ98LwE6vF1KhKj19vk8SrPlfNDxmlBxb2P85A\\nPmzcSKMpPvAscM5I/m5h3xLX1ppq9qVHmNx/sn0ChZVBXbu1VyRWBHd7n0IK+rEv\\npVTJdgvttTk6xkIFTweAVKtUa/zS6A55TskHdtYQSJfTTEgpWgXQxDrsS0GMFl/c\\nI3+YE6cx/ACuyq1vS2OclhisZSG0fyFSX8O0NxrJg/w=\\n=vNwL\\n-----END
-        PGP PUBLIC KEY BLOCK-----\\n\", \n        \"type\": \"PGP\"\n      }, \n      \"last_updated\":
-        \"2018-10-22T22:49:34.518303Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
-        2, \n      \"remove_star_url\": \"/api/v1/sources/6ef758d0-c06b-4e8e-9cad-fe97a95037d1/remove_star\",
-        \n      \"replies_url\": \"/api/v1/sources/6ef758d0-c06b-4e8e-9cad-fe97a95037d1/replies\",
-        \n      \"submissions_url\": \"/api/v1/sources/6ef758d0-c06b-4e8e-9cad-fe97a95037d1/submissions\",
-        \n      \"url\": \"/api/v1/sources/6ef758d0-c06b-4e8e-9cad-fe97a95037d1\",
-        \n      \"uuid\": \"6ef758d0-c06b-4e8e-9cad-fe97a95037d1\"\n    }\n  ]\n}\n"}
-    headers:
-      Content-Length: ['5236']
-      Content-Type: [application/json]
-      Date: ['Mon, 22 Oct 2018 22:49:49 GMT']
-      Server: [Werkzeug/0.14.1 Python/2.7.6]
-      Set-Cookie: [js=eyJleHBpcmVzIjp7IiBkIjoiVHVlLCAyMyBPY3QgMjAxOCAwMDo0OTo0OSBHTVQifX0.Dq_ljQ.eWUawzaEbcP3fX6I2CgzCxXybP4;
-          HttpOnly; Path=/]
-      Vary: [Cookie]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU0MDI3NjkxOCwiaWF0IjoxNTQwMjQ4MTE4fQ.eyJpZCI6MX0.fygpQy3CxB1ulUWLFz2UdrtcBKHz-fk5gyRxbcSY720]
-      Connection: [keep-alive]
-      Content-Type: [application/json]
-      User-Agent: [python-requests/2.20.0]
-    method: GET
-    uri: http://127.0.0.1:8081/api/v1/sources/83442bde-13e7-49a7-b162-646e7f8f87f4/submissions
-  response:
-    body: {string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/83442bde-13e7-49a7-b162-646e7f8f87f4/submissions/5b157795-1f3f-47ad-96ce-a8b6fe69f6e3/download\",
-        \n      \"filename\": \"1-divided_sawdust-msg.gpg\", \n      \"is_read\":
-        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/83442bde-13e7-49a7-b162-646e7f8f87f4\",
-        \n      \"submission_url\": \"/api/v1/sources/83442bde-13e7-49a7-b162-646e7f8f87f4/submissions/5b157795-1f3f-47ad-96ce-a8b6fe69f6e3\",
-        \n      \"uuid\": \"5b157795-1f3f-47ad-96ce-a8b6fe69f6e3\"\n    }, \n    {\n
-        \     \"download_url\": \"/api/v1/sources/83442bde-13e7-49a7-b162-646e7f8f87f4/submissions/50207602-863b-41cd-8451-2af42e45ece8/download\",
-        \n      \"filename\": \"2-divided_sawdust-msg.gpg\", \n      \"is_read\":
-        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/83442bde-13e7-49a7-b162-646e7f8f87f4\",
-        \n      \"submission_url\": \"/api/v1/sources/83442bde-13e7-49a7-b162-646e7f8f87f4/submissions/50207602-863b-41cd-8451-2af42e45ece8\",
-        \n      \"uuid\": \"50207602-863b-41cd-8451-2af42e45ece8\"\n    }\n  ]\n}\n"}
-    headers:
-      Content-Length: ['1033']
-      Content-Type: [application/json]
-      Date: ['Mon, 22 Oct 2018 22:49:49 GMT']
-      Server: [Werkzeug/0.14.1 Python/2.7.6]
-      Set-Cookie: [js=eyJleHBpcmVzIjp7IiBkIjoiVHVlLCAyMyBPY3QgMjAxOCAwMDo0OTo0OSBHTVQifX0.Dq_ljQ.eWUawzaEbcP3fX6I2CgzCxXybP4;
-          HttpOnly; Path=/]
-      Vary: [Cookie]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU0MDI3NjkxOCwiaWF0IjoxNTQwMjQ4MTE4fQ.eyJpZCI6MX0.fygpQy3CxB1ulUWLFz2UdrtcBKHz-fk5gyRxbcSY720]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json]
-      User-Agent: [python-requests/2.20.0]
-    method: DELETE
-    uri: http://127.0.0.1:8081/api/v1/sources/83442bde-13e7-49a7-b162-646e7f8f87f4/submissions/5b157795-1f3f-47ad-96ce-a8b6fe69f6e3
-  response:
-    body: {string: "{\n  \"message\": \"Submission deleted\"\n}\n"}
-    headers:
-      Content-Length: ['38']
-      Content-Type: [application/json]
-      Date: ['Mon, 22 Oct 2018 22:49:49 GMT']
-      Server: [Werkzeug/0.14.1 Python/2.7.6]
-      Set-Cookie: [js=eyJleHBpcmVzIjp7IiBkIjoiVHVlLCAyMyBPY3QgMjAxOCAwMDo0OTo0OSBHTVQifX0.Dq_ljQ.eWUawzaEbcP3fX6I2CgzCxXybP4;
-          HttpOnly; Path=/]
-      Vary: [Cookie]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU0MDI3NjkxOCwiaWF0IjoxNTQwMjQ4MTE4fQ.eyJpZCI6MX0.fygpQy3CxB1ulUWLFz2UdrtcBKHz-fk5gyRxbcSY720]
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1MzA0ODE4MCwiaWF0IjoxNTUzMDE5MzgwfQ.eyJpZCI6MX0.GMXycngr1NHsQ6SoOXCPWqbgPOdHwvYVxKoggrxLYuE]
       Connection: [keep-alive]
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
     uri: http://127.0.0.1:8081/api/v1/submissions
   response:
-    body: {string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/83442bde-13e7-49a7-b162-646e7f8f87f4/submissions/50207602-863b-41cd-8451-2af42e45ece8/download\",
-        \n      \"filename\": \"2-divided_sawdust-msg.gpg\", \n      \"is_read\":
-        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/83442bde-13e7-49a7-b162-646e7f8f87f4\",
-        \n      \"submission_url\": \"/api/v1/sources/83442bde-13e7-49a7-b162-646e7f8f87f4/submissions/50207602-863b-41cd-8451-2af42e45ece8\",
-        \n      \"uuid\": \"50207602-863b-41cd-8451-2af42e45ece8\"\n    }, \n    {\n
-        \     \"download_url\": \"/api/v1/sources/6ef758d0-c06b-4e8e-9cad-fe97a95037d1/submissions/158ed35e-63b2-467f-9603-27b135abff1c/download\",
-        \n      \"filename\": \"1-uniform_boondoggle-msg.gpg\", \n      \"is_read\":
-        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/6ef758d0-c06b-4e8e-9cad-fe97a95037d1\",
-        \n      \"submission_url\": \"/api/v1/sources/6ef758d0-c06b-4e8e-9cad-fe97a95037d1/submissions/158ed35e-63b2-467f-9603-27b135abff1c\",
-        \n      \"uuid\": \"158ed35e-63b2-467f-9603-27b135abff1c\"\n    }, \n    {\n
-        \     \"download_url\": \"/api/v1/sources/6ef758d0-c06b-4e8e-9cad-fe97a95037d1/submissions/9642eccb-e210-4bc3-8025-2cd4f019a582/download\",
-        \n      \"filename\": \"2-uniform_boondoggle-msg.gpg\", \n      \"is_read\":
-        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/6ef758d0-c06b-4e8e-9cad-fe97a95037d1\",
-        \n      \"submission_url\": \"/api/v1/sources/6ef758d0-c06b-4e8e-9cad-fe97a95037d1/submissions/9642eccb-e210-4bc3-8025-2cd4f019a582\",
-        \n      \"uuid\": \"9642eccb-e210-4bc3-8025-2cd4f019a582\"\n    }\n  ]\n}\n"}
+    body: {string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions/f36c2b09-cbc3-4e14-aad3-a8b2c7d5fb80/download\",
+        \n      \"filename\": \"2-seamed_betel-msg.gpg\", \n      \"is_read\": false,
+        \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce\",
+        \n      \"submission_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions/f36c2b09-cbc3-4e14-aad3-a8b2c7d5fb80\",
+        \n      \"uuid\": \"f36c2b09-cbc3-4e14-aad3-a8b2c7d5fb80\"\n    }, \n    {\n
+        \     \"download_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions/75ff4e45-891d-41a5-bc83-ad162c03dcb7/download\",
+        \n      \"filename\": \"1-exasperating_microscope-msg.gpg\", \n      \"is_read\":
+        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86\",
+        \n      \"submission_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions/75ff4e45-891d-41a5-bc83-ad162c03dcb7\",
+        \n      \"uuid\": \"75ff4e45-891d-41a5-bc83-ad162c03dcb7\"\n    }, \n    {\n
+        \     \"download_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions/c0a5a4b0-8889-41d0-9380-fedd608b7e7d/download\",
+        \n      \"filename\": \"2-exasperating_microscope-msg.gpg\", \n      \"is_read\":
+        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86\",
+        \n      \"submission_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions/c0a5a4b0-8889-41d0-9380-fedd608b7e7d\",
+        \n      \"uuid\": \"c0a5a4b0-8889-41d0-9380-fedd608b7e7d\"\n    }\n  ]\n}\n"}
     headers:
-      Content-Length: ['1543']
+      Content-Length: ['1550']
       Content-Type: [application/json]
-      Date: ['Mon, 22 Oct 2018 22:49:49 GMT']
-      Server: [Werkzeug/0.14.1 Python/2.7.6]
-      Set-Cookie: [js=eyJleHBpcmVzIjp7IiBkIjoiVHVlLCAyMyBPY3QgMjAxOCAwMDo0OTo0OSBHTVQifX0.Dq_ljQ.eWUawzaEbcP3fX6I2CgzCxXybP4;
-          HttpOnly; Path=/]
-      Vary: [Cookie]
+      Date: ['Tue, 19 Mar 2019 18:16:20 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1MzA0ODE4MCwiaWF0IjoxNTUzMDE5MzgwfQ.eyJpZCI6MX0.GMXycngr1NHsQ6SoOXCPWqbgPOdHwvYVxKoggrxLYuE]
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: http://127.0.0.1:8081/api/v1/sources
+  response:
+    body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/add_star\",
+        \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
+        false, \n      \"journalist_designation\": \"seamed betel\", \n      \"key\":
+        {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFGRfoABEADb9T/kz6wfGMdHgRyl0VqXmolVe2ll6m2ULXQMJ0F75OmgEMqX\\nQS7JF/GoyPUWfAr3KW5t1f909w29GKfOHcel48pTXwIjpBeYXkwgV/wQQ7l8jj1g\\nII/jv0EP5a8/DiP5tRjQ8/mO0wSdzZU9nWEdohvkHwvTuxjpUtiN8/qqo8cQU1uf\\n78Psnsb3SEP5J5debt/TfEaTg7YdEnTUo50WMVksp6tVyl4vsE7Pi/Rt46+Ww/Cx\\nGfVjI8YxZR7/CGft6IW6pJIIymwnaVotFOd0gZGoj+kvA3D31uHO+2JYpA2G8oQj\\n6Url/60zSh6IjBy5suV+ioP6LnjOlvi2KQjtHwzckxxIsv/CzJvcPUK4j4k8Jwuv\\nmyT6s7BFteY8dqyGbwaF75zh2OFno7YtHKtw+ktWG/zRUKHL31ztA+dukMOfNj1y\\nkUoNQjUz5yUKhhxCM7mS+8AGv6qWH9wRcewpqxG97YxBWGVtSs742sGShrzrLuP4\\nUtrmSd95CSxLe5RXbSbqWpBZ0Bm6fcTv1gw6R1exfQyIbdOS/lfC+HnnsWBRFgX9\\nKjQ3d253wDTe5X30FYRGvuxE2zyAczOuki4ZFYszViwGWH81xvjv8Iv/ypwgsua+\\nRc1SPIpC4EI38+N4hclbprv92x6CS+xlDGl12XK6kWE2v9ZqW95xX4sCzwARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8SFRERFo2UElZTEU3U0RGWVRDN1FQM1BNTklB\\nVEI1WFRFUExOUVFMTEpKV05QQ0lZV1paUlE3R05KWTJPRzVCTEFXMlo1NExQVkdO\\nNVNaWFdURkVXSExFS0pIVEZKSUpMNk9BUFlWUT0+iQI3BBMBCgAhBQJRkX6AAhsv\\nBQsJCAcCBhUICQoLAgQWAgMBAh4BAheAAAoJEEtk3eaziePUQ1cQAMg52/7/qN9t\\nkD7Qdb2X1Bpz+ZSHpWqqPpLWCWXwanZALFXommqTOxDHrsZahwaO4YkW1HsNzC9K\\nwdzhKeQfmtE8NBY53nKzdeLJ5HDFq9daa2CDzIwjiCWG7RC9cMYGxuI9RzvMPMxt\\nusHmR2HV+SCipMp+3mAyUaStkqWyeDHZBqPSw2zFy+sJ4t418yl4pf64eu1zKB7x\\nhpyMnoiSx0wYqwLlfSipDdk4+13eVjJgiIjPxmJYfkMRFEAZVVOPUXsNHUSV83OT\\nybnX4nE9+JlwQFrqgg8uLNyEJh+10WYO37Dt4gKy5iR2rJ316ANxe+g41Lxwz+VA\\nDgrJl/OpfhMqf3epwerzPnhqfpn6NgasyNdx+iHr/Z45jLSdGos89mJ3QJwcbjSi\\nwlDSNnMLtFmuxb1wtx9uaIcCIsIbqGAuaMiq7QDHdktp37cqfdCdS2RTGwqibz0V\\n/cWmHuF1r5jwUPUEGpXCaP6eI4J2zBG11BB7xLKwJmIPbrQuDScCinxmpQVN+BIy\\nSG9j4sd1z2CXKr3dyf++tyPol4+QTweTbpSxE+tOeokI3g9Pv/UqBc/lvmAqPJUR\\nvaq8HKGwHWe03mf6bH5CoXb76QlWVB7SbLju0Zct7B2Tt9+pDea5aivqMQJ78VPu\\nS4uu4UfPHvQU+V2sVvOsT127PyhysBvM\\n=n7gc\\n-----END
+        PGP PUBLIC KEY BLOCK-----\\n\", \n        \"type\": \"PGP\"\n      }, \n      \"last_updated\":
+        \"2019-03-19T18:04:56.323543Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
+        1, \n      \"remove_star_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/remove_star\",
+        \n      \"replies_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/replies\",
+        \n      \"submissions_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions\",
+        \n      \"url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce\",
+        \n      \"uuid\": \"56208324-861b-4d2b-ac4e-555d516f24ce\"\n    }, \n    {\n
+        \     \"add_star_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/add_star\",
+        \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
+        false, \n      \"journalist_designation\": \"exasperating microscope\", \n
+        \     \"key\": {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFGRfoABEADKFFsV9PHRYbM9Dk4sDphjk/g8GEJky4kUzZwsD/Z/8DMRYJZw\\nJlkevyBDw5pZr/NhLtGOf085jSwG6O6nr7QTuJOI7Szh2Ib0r30jJwfL1LdWj/6N\\nf4iXVHzk817NSd//c2V7Qu59opHrxIUntfgiIEjj29EgpnoWWuJ4pe4gvfz/WS2G\\nKPPzFVm9CfZ8xc4YBl2l+rP1AIL+LdIWzcTq+/Y7f7nMdOsKYgaHnmjqZ1EIu0R9\\nR40hBDiqTpeoDhn7mwVG2N2Z+hxqHLxstr2m+o66p6xbo5yeWn/rQATueyd0lt/+\\nD/szhl78657zIYuVFMflQibbMz8hPubFVqEv2tiAp9Ul1sZfUPYr0bBjAXzMYllP\\nZDflpJF5AlDTNOr20zsAHUW8fYnm/YiPvM5Gjz9QfRTpa9C6yHceqk75Cr0AKB+q\\nhIQrt7B/J9EMOdkRyERZBewu4DcUHP+pRES+2at1C6d6Qunp6QQPcfILfJS6Bp3H\\nY4tbNl7neqhPQu/GsDD1CDoOiclOgLHUBnDH9ef80jGoCffO3qQDzckQ8S0xrORs\\nxaa6YSsj2u8XL7QbDe0WUFrypUE0Y/4kETw27qtH5xBISHcJbO5tLDllEHCJxAvX\\nNyIv6YvcpNXCh/F2dLP2x1vRt2xayLD5Xd+T/xtCaMdMWJiYu1Qj65uIMQARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8T1lLRVdSNERKQ1EyTTRYWE5LNjMyNVAzU1pU\\nUkxQM1BBR09ZR01MWVBYTDdIWVpPVTRYRkFMSlFKNzJTQlJaTllRUE5CR0dJNlJX\\nVFdGUlhHS1hUUUtCN0VKNEE1UUI0MlpBUDNEST0+iQI3BBMBCgAhBQJRkX6AAhsv\\nBQsJCAcCBhUICQoLAgQWAgMBAh4BAheAAAoJEFOrutu9FeYMFFEP/22xHEk1Z4jB\\nXxSE7p8hWLaqJgD2BaSOBvqKU5hba91E/RvpTsGjbpmCaHlfLGL8haUQpSFxTW7o\\nR7kiVFdZYjuRCOoOITuH0P2vtVC0VE4/uE3MWF5UWgXeVp5SQz67kgtn9MBV4ZYK\\n1P6cRfZgHfLUsFtEP/U2Z6DjGe580GR9SivCbU2XC3rvcURjZqdvFkT7ABIgjME7\\n4ee0XCFs7oYnzXKZcY9ADrBTTt0d1c9FobavKKJwYs76ZF71WmkfcVEgTaT2DBg+\\nbpAz/3zSX6xSMFUu/VIQ7+iQYstTx/Un9VmV9BnnqwbMeennmQDpc9xC+80kvawD\\nsybSVogVMyjpCweCLYXiP/I1XDu2J3WZIQ1p701fgBvRp4SsPwXWJtE5j2DTQDq6\\noIh9bssdHu8hw0BHXkdprjHRij5Uek8evjbzz9gflat6Vlk2deq7KovFN6nR7xTE\\ngt2XBSoluUlVINN5ozgw/Il5tqDaZDv32hzU7wUmBeQPHvyrm6i9IhiOOTgQr7Wi\\n3DBrUpdXZZNxiKMEoLdAw7VJVXuvCEXELtQBfCoIbuGW7jdWeA+k8C9pxCrOG6O8\\ndNDP33U21/+N9XyMHBCF4TMiLJhhrcvV8/LtJ1t0id3oRm54iwuKel6KL0NQoIE4\\n5tICW7cN9qFg3719pl+SE+t2MqXqoaWO\\n=E8/J\\n-----END
+        PGP PUBLIC KEY BLOCK-----\\n\", \n        \"type\": \"PGP\"\n      }, \n      \"last_updated\":
+        \"2019-03-19T18:04:58.189782Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
+        2, \n      \"remove_star_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/remove_star\",
+        \n      \"replies_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/replies\",
+        \n      \"submissions_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions\",
+        \n      \"url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86\",
+        \n      \"uuid\": \"0755725e-5f7e-436a-be9e-8ac400953b86\"\n    }\n  ]\n}\n"}
+    headers:
+      Content-Length: ['5214']
+      Content-Type: [application/json]
+      Date: ['Tue, 19 Mar 2019 18:16:20 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1MzA0ODE4MCwiaWF0IjoxNTUzMDE5MzgwfQ.eyJpZCI6MX0.GMXycngr1NHsQ6SoOXCPWqbgPOdHwvYVxKoggrxLYuE]
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: http://127.0.0.1:8081/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions
+  response:
+    body: {string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions/f36c2b09-cbc3-4e14-aad3-a8b2c7d5fb80/download\",
+        \n      \"filename\": \"2-seamed_betel-msg.gpg\", \n      \"is_read\": false,
+        \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce\",
+        \n      \"submission_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions/f36c2b09-cbc3-4e14-aad3-a8b2c7d5fb80\",
+        \n      \"uuid\": \"f36c2b09-cbc3-4e14-aad3-a8b2c7d5fb80\"\n    }\n  ]\n}\n"}
+    headers:
+      Content-Length: ['526']
+      Content-Type: [application/json]
+      Date: ['Tue, 19 Mar 2019 18:16:20 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1MzA0ODE4MCwiaWF0IjoxNTUzMDE5MzgwfQ.eyJpZCI6MX0.GMXycngr1NHsQ6SoOXCPWqbgPOdHwvYVxKoggrxLYuE]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: DELETE
+    uri: http://127.0.0.1:8081/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions/f36c2b09-cbc3-4e14-aad3-a8b2c7d5fb80
+  response:
+    body: {string: "{\n  \"message\": \"Submission deleted\"\n}\n"}
+    headers:
+      Content-Length: ['38']
+      Content-Type: [application/json]
+      Date: ['Tue, 19 Mar 2019 18:16:20 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1MzA0ODE4MCwiaWF0IjoxNTUzMDE5MzgwfQ.eyJpZCI6MX0.GMXycngr1NHsQ6SoOXCPWqbgPOdHwvYVxKoggrxLYuE]
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: http://127.0.0.1:8081/api/v1/submissions
+  response:
+    body: {string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions/75ff4e45-891d-41a5-bc83-ad162c03dcb7/download\",
+        \n      \"filename\": \"1-exasperating_microscope-msg.gpg\", \n      \"is_read\":
+        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86\",
+        \n      \"submission_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions/75ff4e45-891d-41a5-bc83-ad162c03dcb7\",
+        \n      \"uuid\": \"75ff4e45-891d-41a5-bc83-ad162c03dcb7\"\n    }, \n    {\n
+        \     \"download_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions/c0a5a4b0-8889-41d0-9380-fedd608b7e7d/download\",
+        \n      \"filename\": \"2-exasperating_microscope-msg.gpg\", \n      \"is_read\":
+        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86\",
+        \n      \"submission_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions/c0a5a4b0-8889-41d0-9380-fedd608b7e7d\",
+        \n      \"uuid\": \"c0a5a4b0-8889-41d0-9380-fedd608b7e7d\"\n    }\n  ]\n}\n"}
+    headers:
+      Content-Length: ['1049']
+      Content-Type: [application/json]
+      Date: ['Tue, 19 Mar 2019 18:16:20 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
     status: {code: 200, message: OK}
 version: 1

--- a/data/test-delete-submission.yml
+++ b/data/test-delete-submission.yml
@@ -9,7 +9,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/submissions
+    uri: http://127.0.0.1:8081/api/v1/submissions
   response:
     body: {string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/58393a75-75b4-4c9b-9696-9b15741d0e19/submissions/e476e1a2-0f8b-4708-977a-23ce0c5ce2ff/download\",
         \n      \"filename\": \"1-unfulfilled_ardor-msg.gpg\", \n      \"is_read\":
@@ -51,7 +51,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: DELETE
-    uri: http://localhost:8081/api/v1/sources/58393a75-75b4-4c9b-9696-9b15741d0e19/submissions/e476e1a2-0f8b-4708-977a-23ce0c5ce2ff
+    uri: http://127.0.0.1:8081/api/v1/sources/58393a75-75b4-4c9b-9696-9b15741d0e19/submissions/e476e1a2-0f8b-4708-977a-23ce0c5ce2ff
   response:
     body: {string: "{\n  \"message\": \"Submission deleted\"\n}\n"}
     headers:
@@ -73,7 +73,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/submissions
+    uri: http://127.0.0.1:8081/api/v1/submissions
   response:
     body: {string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/58393a75-75b4-4c9b-9696-9b15741d0e19/submissions/25670770-6772-439b-8ce4-733799dc32f8/download\",
         \n      \"filename\": \"2-unfulfilled_ardor-msg.gpg\", \n      \"is_read\":

--- a/data/test-delete-submission.yml
+++ b/data/test-delete-submission.yml
@@ -4,99 +4,128 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU0MDI3NjkxOCwiaWF0IjoxNTQwMjQ4MTE4fQ.eyJpZCI6MX0.fygpQy3CxB1ulUWLFz2UdrtcBKHz-fk5gyRxbcSY720]
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1MzA0ODE1OSwiaWF0IjoxNTUzMDE5MzU5fQ.eyJpZCI6MX0._1bKHMI2zIWuRatK9QDOO-Xoz-NsDrjVbp_kuFkQJt8]
       Connection: [keep-alive]
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
     uri: http://127.0.0.1:8081/api/v1/submissions
   response:
-    body: {string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/58393a75-75b4-4c9b-9696-9b15741d0e19/submissions/e476e1a2-0f8b-4708-977a-23ce0c5ce2ff/download\",
-        \n      \"filename\": \"1-unfulfilled_ardor-msg.gpg\", \n      \"is_read\":
-        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/58393a75-75b4-4c9b-9696-9b15741d0e19\",
-        \n      \"submission_url\": \"/api/v1/sources/58393a75-75b4-4c9b-9696-9b15741d0e19/submissions/e476e1a2-0f8b-4708-977a-23ce0c5ce2ff\",
-        \n      \"uuid\": \"e476e1a2-0f8b-4708-977a-23ce0c5ce2ff\"\n    }, \n    {\n
-        \     \"download_url\": \"/api/v1/sources/58393a75-75b4-4c9b-9696-9b15741d0e19/submissions/25670770-6772-439b-8ce4-733799dc32f8/download\",
-        \n      \"filename\": \"2-unfulfilled_ardor-msg.gpg\", \n      \"is_read\":
-        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/58393a75-75b4-4c9b-9696-9b15741d0e19\",
-        \n      \"submission_url\": \"/api/v1/sources/58393a75-75b4-4c9b-9696-9b15741d0e19/submissions/25670770-6772-439b-8ce4-733799dc32f8\",
-        \n      \"uuid\": \"25670770-6772-439b-8ce4-733799dc32f8\"\n    }, \n    {\n
-        \     \"download_url\": \"/api/v1/sources/1535642d-7070-46b3-876a-e466a89addbb/submissions/3b11ac7b-6533-4911-936f-c3e8eb484ece/download\",
-        \n      \"filename\": \"1-smooth-skinned_salad-msg.gpg\", \n      \"is_read\":
-        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/1535642d-7070-46b3-876a-e466a89addbb\",
-        \n      \"submission_url\": \"/api/v1/sources/1535642d-7070-46b3-876a-e466a89addbb/submissions/3b11ac7b-6533-4911-936f-c3e8eb484ece\",
-        \n      \"uuid\": \"3b11ac7b-6533-4911-936f-c3e8eb484ece\"\n    }, \n    {\n
-        \     \"download_url\": \"/api/v1/sources/1535642d-7070-46b3-876a-e466a89addbb/submissions/0fdd8eee-1145-44f2-9cc7-7b5b64575916/download\",
-        \n      \"filename\": \"2-smooth-skinned_salad-msg.gpg\", \n      \"is_read\":
-        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/1535642d-7070-46b3-876a-e466a89addbb\",
-        \n      \"submission_url\": \"/api/v1/sources/1535642d-7070-46b3-876a-e466a89addbb/submissions/0fdd8eee-1145-44f2-9cc7-7b5b64575916\",
-        \n      \"uuid\": \"0fdd8eee-1145-44f2-9cc7-7b5b64575916\"\n    }\n  ]\n}\n"}
+    body: {string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions/ae7e372b-21e5-4709-bb60-82ce5c6e13e3/download\",
+        \n      \"filename\": \"1-seamed_betel-msg.gpg\", \n      \"is_read\": false,
+        \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce\",
+        \n      \"submission_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions/ae7e372b-21e5-4709-bb60-82ce5c6e13e3\",
+        \n      \"uuid\": \"ae7e372b-21e5-4709-bb60-82ce5c6e13e3\"\n    }, \n    {\n
+        \     \"download_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions/f36c2b09-cbc3-4e14-aad3-a8b2c7d5fb80/download\",
+        \n      \"filename\": \"2-seamed_betel-msg.gpg\", \n      \"is_read\": false,
+        \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce\",
+        \n      \"submission_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions/f36c2b09-cbc3-4e14-aad3-a8b2c7d5fb80\",
+        \n      \"uuid\": \"f36c2b09-cbc3-4e14-aad3-a8b2c7d5fb80\"\n    }, \n    {\n
+        \     \"download_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions/75ff4e45-891d-41a5-bc83-ad162c03dcb7/download\",
+        \n      \"filename\": \"1-exasperating_microscope-msg.gpg\", \n      \"is_read\":
+        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86\",
+        \n      \"submission_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions/75ff4e45-891d-41a5-bc83-ad162c03dcb7\",
+        \n      \"uuid\": \"75ff4e45-891d-41a5-bc83-ad162c03dcb7\"\n    }, \n    {\n
+        \     \"download_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions/c0a5a4b0-8889-41d0-9380-fedd608b7e7d/download\",
+        \n      \"filename\": \"2-exasperating_microscope-msg.gpg\", \n      \"is_read\":
+        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86\",
+        \n      \"submission_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions/c0a5a4b0-8889-41d0-9380-fedd608b7e7d\",
+        \n      \"uuid\": \"c0a5a4b0-8889-41d0-9380-fedd608b7e7d\"\n    }\n  ]\n}\n"}
     headers:
-      Content-Length: ['2055']
+      Content-Length: ['2051']
       Content-Type: [application/json]
-      Date: ['Mon, 22 Oct 2018 22:49:15 GMT']
-      Server: [Werkzeug/0.14.1 Python/2.7.6]
-      Set-Cookie: [js=eyJleHBpcmVzIjp7IiBkIjoiVHVlLCAyMyBPY3QgMjAxOCAwMDo0OToxNSBHTVQifX0.Dq_law.s7_brzLOZRLNGAyi6O99Upfpq8o;
-          HttpOnly; Path=/]
-      Vary: [Cookie]
+      Date: ['Tue, 19 Mar 2019 18:15:59 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU0MDI3NjkxOCwiaWF0IjoxNTQwMjQ4MTE4fQ.eyJpZCI6MX0.fygpQy3CxB1ulUWLFz2UdrtcBKHz-fk5gyRxbcSY720]
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1MzA0ODE1OSwiaWF0IjoxNTUzMDE5MzU5fQ.eyJpZCI6MX0._1bKHMI2zIWuRatK9QDOO-Xoz-NsDrjVbp_kuFkQJt8]
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: http://127.0.0.1:8081/api/v1/submissions
+  response:
+    body: {string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions/ae7e372b-21e5-4709-bb60-82ce5c6e13e3/download\",
+        \n      \"filename\": \"1-seamed_betel-msg.gpg\", \n      \"is_read\": false,
+        \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce\",
+        \n      \"submission_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions/ae7e372b-21e5-4709-bb60-82ce5c6e13e3\",
+        \n      \"uuid\": \"ae7e372b-21e5-4709-bb60-82ce5c6e13e3\"\n    }, \n    {\n
+        \     \"download_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions/f36c2b09-cbc3-4e14-aad3-a8b2c7d5fb80/download\",
+        \n      \"filename\": \"2-seamed_betel-msg.gpg\", \n      \"is_read\": false,
+        \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce\",
+        \n      \"submission_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions/f36c2b09-cbc3-4e14-aad3-a8b2c7d5fb80\",
+        \n      \"uuid\": \"f36c2b09-cbc3-4e14-aad3-a8b2c7d5fb80\"\n    }, \n    {\n
+        \     \"download_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions/75ff4e45-891d-41a5-bc83-ad162c03dcb7/download\",
+        \n      \"filename\": \"1-exasperating_microscope-msg.gpg\", \n      \"is_read\":
+        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86\",
+        \n      \"submission_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions/75ff4e45-891d-41a5-bc83-ad162c03dcb7\",
+        \n      \"uuid\": \"75ff4e45-891d-41a5-bc83-ad162c03dcb7\"\n    }, \n    {\n
+        \     \"download_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions/c0a5a4b0-8889-41d0-9380-fedd608b7e7d/download\",
+        \n      \"filename\": \"2-exasperating_microscope-msg.gpg\", \n      \"is_read\":
+        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86\",
+        \n      \"submission_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions/c0a5a4b0-8889-41d0-9380-fedd608b7e7d\",
+        \n      \"uuid\": \"c0a5a4b0-8889-41d0-9380-fedd608b7e7d\"\n    }\n  ]\n}\n"}
+    headers:
+      Content-Length: ['2051']
+      Content-Type: [application/json]
+      Date: ['Tue, 19 Mar 2019 18:15:59 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1MzA0ODE1OSwiaWF0IjoxNTUzMDE5MzU5fQ.eyJpZCI6MX0._1bKHMI2zIWuRatK9QDOO-Xoz-NsDrjVbp_kuFkQJt8]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: DELETE
-    uri: http://127.0.0.1:8081/api/v1/sources/58393a75-75b4-4c9b-9696-9b15741d0e19/submissions/e476e1a2-0f8b-4708-977a-23ce0c5ce2ff
+    uri: http://127.0.0.1:8081/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions/ae7e372b-21e5-4709-bb60-82ce5c6e13e3
   response:
     body: {string: "{\n  \"message\": \"Submission deleted\"\n}\n"}
     headers:
       Content-Length: ['38']
       Content-Type: [application/json]
-      Date: ['Mon, 22 Oct 2018 22:49:15 GMT']
-      Server: [Werkzeug/0.14.1 Python/2.7.6]
-      Set-Cookie: [js=eyJleHBpcmVzIjp7IiBkIjoiVHVlLCAyMyBPY3QgMjAxOCAwMDo0OToxNSBHTVQifX0.Dq_law.s7_brzLOZRLNGAyi6O99Upfpq8o;
-          HttpOnly; Path=/]
-      Vary: [Cookie]
+      Date: ['Tue, 19 Mar 2019 18:15:59 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU0MDI3NjkxOCwiaWF0IjoxNTQwMjQ4MTE4fQ.eyJpZCI6MX0.fygpQy3CxB1ulUWLFz2UdrtcBKHz-fk5gyRxbcSY720]
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1MzA0ODE1OSwiaWF0IjoxNTUzMDE5MzU5fQ.eyJpZCI6MX0._1bKHMI2zIWuRatK9QDOO-Xoz-NsDrjVbp_kuFkQJt8]
       Connection: [keep-alive]
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
     uri: http://127.0.0.1:8081/api/v1/submissions
   response:
-    body: {string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/58393a75-75b4-4c9b-9696-9b15741d0e19/submissions/25670770-6772-439b-8ce4-733799dc32f8/download\",
-        \n      \"filename\": \"2-unfulfilled_ardor-msg.gpg\", \n      \"is_read\":
-        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/58393a75-75b4-4c9b-9696-9b15741d0e19\",
-        \n      \"submission_url\": \"/api/v1/sources/58393a75-75b4-4c9b-9696-9b15741d0e19/submissions/25670770-6772-439b-8ce4-733799dc32f8\",
-        \n      \"uuid\": \"25670770-6772-439b-8ce4-733799dc32f8\"\n    }, \n    {\n
-        \     \"download_url\": \"/api/v1/sources/1535642d-7070-46b3-876a-e466a89addbb/submissions/3b11ac7b-6533-4911-936f-c3e8eb484ece/download\",
-        \n      \"filename\": \"1-smooth-skinned_salad-msg.gpg\", \n      \"is_read\":
-        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/1535642d-7070-46b3-876a-e466a89addbb\",
-        \n      \"submission_url\": \"/api/v1/sources/1535642d-7070-46b3-876a-e466a89addbb/submissions/3b11ac7b-6533-4911-936f-c3e8eb484ece\",
-        \n      \"uuid\": \"3b11ac7b-6533-4911-936f-c3e8eb484ece\"\n    }, \n    {\n
-        \     \"download_url\": \"/api/v1/sources/1535642d-7070-46b3-876a-e466a89addbb/submissions/0fdd8eee-1145-44f2-9cc7-7b5b64575916/download\",
-        \n      \"filename\": \"2-smooth-skinned_salad-msg.gpg\", \n      \"is_read\":
-        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/1535642d-7070-46b3-876a-e466a89addbb\",
-        \n      \"submission_url\": \"/api/v1/sources/1535642d-7070-46b3-876a-e466a89addbb/submissions/0fdd8eee-1145-44f2-9cc7-7b5b64575916\",
-        \n      \"uuid\": \"0fdd8eee-1145-44f2-9cc7-7b5b64575916\"\n    }\n  ]\n}\n"}
+    body: {string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions/f36c2b09-cbc3-4e14-aad3-a8b2c7d5fb80/download\",
+        \n      \"filename\": \"2-seamed_betel-msg.gpg\", \n      \"is_read\": false,
+        \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce\",
+        \n      \"submission_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions/f36c2b09-cbc3-4e14-aad3-a8b2c7d5fb80\",
+        \n      \"uuid\": \"f36c2b09-cbc3-4e14-aad3-a8b2c7d5fb80\"\n    }, \n    {\n
+        \     \"download_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions/75ff4e45-891d-41a5-bc83-ad162c03dcb7/download\",
+        \n      \"filename\": \"1-exasperating_microscope-msg.gpg\", \n      \"is_read\":
+        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86\",
+        \n      \"submission_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions/75ff4e45-891d-41a5-bc83-ad162c03dcb7\",
+        \n      \"uuid\": \"75ff4e45-891d-41a5-bc83-ad162c03dcb7\"\n    }, \n    {\n
+        \     \"download_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions/c0a5a4b0-8889-41d0-9380-fedd608b7e7d/download\",
+        \n      \"filename\": \"2-exasperating_microscope-msg.gpg\", \n      \"is_read\":
+        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86\",
+        \n      \"submission_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions/c0a5a4b0-8889-41d0-9380-fedd608b7e7d\",
+        \n      \"uuid\": \"c0a5a4b0-8889-41d0-9380-fedd608b7e7d\"\n    }\n  ]\n}\n"}
     headers:
-      Content-Length: ['1549']
+      Content-Length: ['1550']
       Content-Type: [application/json]
-      Date: ['Mon, 22 Oct 2018 22:49:15 GMT']
-      Server: [Werkzeug/0.14.1 Python/2.7.6]
-      Set-Cookie: [js=eyJleHBpcmVzIjp7IiBkIjoiVHVlLCAyMyBPY3QgMjAxOCAwMDo0OToxNSBHTVQifX0.Dq_law.s7_brzLOZRLNGAyi6O99Upfpq8o;
-          HttpOnly; Path=/]
-      Vary: [Cookie]
+      Date: ['Tue, 19 Mar 2019 18:15:59 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
     status: {code: 200, message: OK}
 version: 1

--- a/data/test-download-reply.yml
+++ b/data/test-download-reply.yml
@@ -9,7 +9,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/replies
+    uri: http://127.0.0.1:8081/api/v1/replies
   response:
     body: {string: "{\n  \"replies\": [\n    {\n      \"filename\": \"3-bumptious_arthropod-reply.gpg\",
         \n      \"is_deleted_by_source\": false, \n      \"journalist_username\":
@@ -51,7 +51,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources/1f0a8826-a118-4a2f-b295-4abc0b41e1b8/replies/e1f1db54-9cd7-41f3-907d-6a260e269a60/download
+    uri: http://127.0.0.1:8081/api/v1/sources/1f0a8826-a118-4a2f-b295-4abc0b41e1b8/replies/e1f1db54-9cd7-41f3-907d-6a260e269a60/download
   response:
     body:
       string: !!binary |

--- a/data/test-download-submission.yml
+++ b/data/test-download-submission.yml
@@ -9,7 +9,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/submissions
+    uri: http://127.0.0.1:8081/api/v1/submissions
   response:
     body: {string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/a4f133ff-ba19-4986-a2bd-735b6c33be75/submissions/455db36c-16c5-455e-b06f-5e3e8fc6a8b6/download\",
         \n      \"filename\": \"1-structural_ageratum-msg.gpg\", \n      \"is_read\":
@@ -50,7 +50,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources/a4f133ff-ba19-4986-a2bd-735b6c33be75/submissions/455db36c-16c5-455e-b06f-5e3e8fc6a8b6/download
+    uri: http://127.0.0.1:8081/api/v1/sources/a4f133ff-ba19-4986-a2bd-735b6c33be75/submissions/455db36c-16c5-455e-b06f-5e3e8fc6a8b6/download
   response:
     body:
       string: !!binary |
@@ -89,7 +89,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources/a4f133ff-ba19-4986-a2bd-735b6c33be75/submissions/455db36c-16c5-455e-b06f-5e3e8fc6a8b6
+    uri: http://127.0.0.1:8081/api/v1/sources/a4f133ff-ba19-4986-a2bd-735b6c33be75/submissions/455db36c-16c5-455e-b06f-5e3e8fc6a8b6
   response:
     body: {string: "{\n  \"download_url\": \"/api/v1/sources/a4f133ff-ba19-4986-a2bd-735b6c33be75/submissions/455db36c-16c5-455e-b06f-5e3e8fc6a8b6/download\",
         \n  \"filename\": \"1-structural_ageratum-msg.gpg\", \n  \"is_read\": true,

--- a/data/test-error-unencrypted-reply.yml
+++ b/data/test-error-unencrypted-reply.yml
@@ -9,7 +9,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources
+    uri: http://127.0.0.1:8081/api/v1/sources
   response:
     body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/c3d4c09c-8bc5-4465-a980-a16c747a869d/add_star\",
         \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
@@ -53,7 +53,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: POST
-    uri: http://localhost:8081/api/v1/sources/c3d4c09c-8bc5-4465-a980-a16c747a869d/replies
+    uri: http://127.0.0.1:8081/api/v1/sources/c3d4c09c-8bc5-4465-a980-a16c747a869d/replies
   response:
     body: {string: "{\n  \"message\": \"You must encrypt replies client side\"\n}\n"}
     headers:

--- a/data/test-failed-single-source.yml
+++ b/data/test-failed-single-source.yml
@@ -9,7 +9,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources/not%20there
+    uri: http://127.0.0.1:8081/api/v1/sources/not%20there
   response:
     body: {string: "{\n  \"error\": \"Not Found\", \n  \"message\": \"The requested
         URL was not found on the server.  If you entered the URL manually please check

--- a/data/test-flag-source.yml
+++ b/data/test-flag-source.yml
@@ -9,7 +9,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources
+    uri: http://127.0.0.1:8081/api/v1/sources
   response:
     body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/bee5c707-de42-4087-886a-1a5cc382467a/add_star\",
         \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
@@ -53,7 +53,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: POST
-    uri: http://localhost:8081/api/v1/sources/bee5c707-de42-4087-886a-1a5cc382467a/flag
+    uri: http://127.0.0.1:8081/api/v1/sources/bee5c707-de42-4087-886a-1a5cc382467a/flag
   response:
     body: {string: "{\n  \"message\": \"Source flagged for reply\"\n}\n"}
     headers:
@@ -75,7 +75,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources/bee5c707-de42-4087-886a-1a5cc382467a
+    uri: http://127.0.0.1:8081/api/v1/sources/bee5c707-de42-4087-886a-1a5cc382467a
   response:
     body: {string: "{\n  \"add_star_url\": \"/api/v1/sources/bee5c707-de42-4087-886a-1a5cc382467a/add_star\",
         \n  \"interaction_count\": 4, \n  \"is_flagged\": true, \n  \"is_starred\":

--- a/data/test-get-all-replies.yml
+++ b/data/test-get-all-replies.yml
@@ -9,7 +9,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/replies
+    uri: http://127.0.0.1:8081/api/v1/replies
   response:
     body: {string: "{\n  \"replies\": [\n    {\n      \"filename\": \"3-concealed_straight-reply.gpg\",
         \n      \"is_deleted_by_source\": false, \n      \"journalist_username\":

--- a/data/test-get-all-replies.yml
+++ b/data/test-get-all-replies.yml
@@ -4,41 +4,78 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU0MDI3NjkxOCwiaWF0IjoxNTQwMjQ4MTE4fQ.eyJpZCI6MX0.fygpQy3CxB1ulUWLFz2UdrtcBKHz-fk5gyRxbcSY720]
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1MzA0ODIyNiwiaWF0IjoxNTUzMDE5NDI2fQ.eyJpZCI6MX0.qO9kEj8hcA2p2_hGHde8ZGuu2PfvylxTYkoQpt8evvc]
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: http://127.0.0.1:8081/api/v1/sources
+  response:
+    body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/add_star\",
+        \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
+        false, \n      \"journalist_designation\": \"seamed betel\", \n      \"key\":
+        {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFGRfoABEADb9T/kz6wfGMdHgRyl0VqXmolVe2ll6m2ULXQMJ0F75OmgEMqX\\nQS7JF/GoyPUWfAr3KW5t1f909w29GKfOHcel48pTXwIjpBeYXkwgV/wQQ7l8jj1g\\nII/jv0EP5a8/DiP5tRjQ8/mO0wSdzZU9nWEdohvkHwvTuxjpUtiN8/qqo8cQU1uf\\n78Psnsb3SEP5J5debt/TfEaTg7YdEnTUo50WMVksp6tVyl4vsE7Pi/Rt46+Ww/Cx\\nGfVjI8YxZR7/CGft6IW6pJIIymwnaVotFOd0gZGoj+kvA3D31uHO+2JYpA2G8oQj\\n6Url/60zSh6IjBy5suV+ioP6LnjOlvi2KQjtHwzckxxIsv/CzJvcPUK4j4k8Jwuv\\nmyT6s7BFteY8dqyGbwaF75zh2OFno7YtHKtw+ktWG/zRUKHL31ztA+dukMOfNj1y\\nkUoNQjUz5yUKhhxCM7mS+8AGv6qWH9wRcewpqxG97YxBWGVtSs742sGShrzrLuP4\\nUtrmSd95CSxLe5RXbSbqWpBZ0Bm6fcTv1gw6R1exfQyIbdOS/lfC+HnnsWBRFgX9\\nKjQ3d253wDTe5X30FYRGvuxE2zyAczOuki4ZFYszViwGWH81xvjv8Iv/ypwgsua+\\nRc1SPIpC4EI38+N4hclbprv92x6CS+xlDGl12XK6kWE2v9ZqW95xX4sCzwARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8SFRERFo2UElZTEU3U0RGWVRDN1FQM1BNTklB\\nVEI1WFRFUExOUVFMTEpKV05QQ0lZV1paUlE3R05KWTJPRzVCTEFXMlo1NExQVkdO\\nNVNaWFdURkVXSExFS0pIVEZKSUpMNk9BUFlWUT0+iQI3BBMBCgAhBQJRkX6AAhsv\\nBQsJCAcCBhUICQoLAgQWAgMBAh4BAheAAAoJEEtk3eaziePUQ1cQAMg52/7/qN9t\\nkD7Qdb2X1Bpz+ZSHpWqqPpLWCWXwanZALFXommqTOxDHrsZahwaO4YkW1HsNzC9K\\nwdzhKeQfmtE8NBY53nKzdeLJ5HDFq9daa2CDzIwjiCWG7RC9cMYGxuI9RzvMPMxt\\nusHmR2HV+SCipMp+3mAyUaStkqWyeDHZBqPSw2zFy+sJ4t418yl4pf64eu1zKB7x\\nhpyMnoiSx0wYqwLlfSipDdk4+13eVjJgiIjPxmJYfkMRFEAZVVOPUXsNHUSV83OT\\nybnX4nE9+JlwQFrqgg8uLNyEJh+10WYO37Dt4gKy5iR2rJ316ANxe+g41Lxwz+VA\\nDgrJl/OpfhMqf3epwerzPnhqfpn6NgasyNdx+iHr/Z45jLSdGos89mJ3QJwcbjSi\\nwlDSNnMLtFmuxb1wtx9uaIcCIsIbqGAuaMiq7QDHdktp37cqfdCdS2RTGwqibz0V\\n/cWmHuF1r5jwUPUEGpXCaP6eI4J2zBG11BB7xLKwJmIPbrQuDScCinxmpQVN+BIy\\nSG9j4sd1z2CXKr3dyf++tyPol4+QTweTbpSxE+tOeokI3g9Pv/UqBc/lvmAqPJUR\\nvaq8HKGwHWe03mf6bH5CoXb76QlWVB7SbLju0Zct7B2Tt9+pDea5aivqMQJ78VPu\\nS4uu4UfPHvQU+V2sVvOsT127PyhysBvM\\n=n7gc\\n-----END
+        PGP PUBLIC KEY BLOCK-----\\n\", \n        \"type\": \"PGP\"\n      }, \n      \"last_updated\":
+        \"2019-03-19T18:04:56.323543Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
+        0, \n      \"remove_star_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/remove_star\",
+        \n      \"replies_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/replies\",
+        \n      \"submissions_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions\",
+        \n      \"url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce\",
+        \n      \"uuid\": \"56208324-861b-4d2b-ac4e-555d516f24ce\"\n    }, \n    {\n
+        \     \"add_star_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/add_star\",
+        \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
+        false, \n      \"journalist_designation\": \"exasperating microscope\", \n
+        \     \"key\": {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFGRfoABEADKFFsV9PHRYbM9Dk4sDphjk/g8GEJky4kUzZwsD/Z/8DMRYJZw\\nJlkevyBDw5pZr/NhLtGOf085jSwG6O6nr7QTuJOI7Szh2Ib0r30jJwfL1LdWj/6N\\nf4iXVHzk817NSd//c2V7Qu59opHrxIUntfgiIEjj29EgpnoWWuJ4pe4gvfz/WS2G\\nKPPzFVm9CfZ8xc4YBl2l+rP1AIL+LdIWzcTq+/Y7f7nMdOsKYgaHnmjqZ1EIu0R9\\nR40hBDiqTpeoDhn7mwVG2N2Z+hxqHLxstr2m+o66p6xbo5yeWn/rQATueyd0lt/+\\nD/szhl78657zIYuVFMflQibbMz8hPubFVqEv2tiAp9Ul1sZfUPYr0bBjAXzMYllP\\nZDflpJF5AlDTNOr20zsAHUW8fYnm/YiPvM5Gjz9QfRTpa9C6yHceqk75Cr0AKB+q\\nhIQrt7B/J9EMOdkRyERZBewu4DcUHP+pRES+2at1C6d6Qunp6QQPcfILfJS6Bp3H\\nY4tbNl7neqhPQu/GsDD1CDoOiclOgLHUBnDH9ef80jGoCffO3qQDzckQ8S0xrORs\\nxaa6YSsj2u8XL7QbDe0WUFrypUE0Y/4kETw27qtH5xBISHcJbO5tLDllEHCJxAvX\\nNyIv6YvcpNXCh/F2dLP2x1vRt2xayLD5Xd+T/xtCaMdMWJiYu1Qj65uIMQARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8T1lLRVdSNERKQ1EyTTRYWE5LNjMyNVAzU1pU\\nUkxQM1BBR09ZR01MWVBYTDdIWVpPVTRYRkFMSlFKNzJTQlJaTllRUE5CR0dJNlJX\\nVFdGUlhHS1hUUUtCN0VKNEE1UUI0MlpBUDNEST0+iQI3BBMBCgAhBQJRkX6AAhsv\\nBQsJCAcCBhUICQoLAgQWAgMBAh4BAheAAAoJEFOrutu9FeYMFFEP/22xHEk1Z4jB\\nXxSE7p8hWLaqJgD2BaSOBvqKU5hba91E/RvpTsGjbpmCaHlfLGL8haUQpSFxTW7o\\nR7kiVFdZYjuRCOoOITuH0P2vtVC0VE4/uE3MWF5UWgXeVp5SQz67kgtn9MBV4ZYK\\n1P6cRfZgHfLUsFtEP/U2Z6DjGe580GR9SivCbU2XC3rvcURjZqdvFkT7ABIgjME7\\n4ee0XCFs7oYnzXKZcY9ADrBTTt0d1c9FobavKKJwYs76ZF71WmkfcVEgTaT2DBg+\\nbpAz/3zSX6xSMFUu/VIQ7+iQYstTx/Un9VmV9BnnqwbMeennmQDpc9xC+80kvawD\\nsybSVogVMyjpCweCLYXiP/I1XDu2J3WZIQ1p701fgBvRp4SsPwXWJtE5j2DTQDq6\\noIh9bssdHu8hw0BHXkdprjHRij5Uek8evjbzz9gflat6Vlk2deq7KovFN6nR7xTE\\ngt2XBSoluUlVINN5ozgw/Il5tqDaZDv32hzU7wUmBeQPHvyrm6i9IhiOOTgQr7Wi\\n3DBrUpdXZZNxiKMEoLdAw7VJVXuvCEXELtQBfCoIbuGW7jdWeA+k8C9pxCrOG6O8\\ndNDP33U21/+N9XyMHBCF4TMiLJhhrcvV8/LtJ1t0id3oRm54iwuKel6KL0NQoIE4\\n5tICW7cN9qFg3719pl+SE+t2MqXqoaWO\\n=E8/J\\n-----END
+        PGP PUBLIC KEY BLOCK-----\\n\", \n        \"type\": \"PGP\"\n      }, \n      \"last_updated\":
+        \"2019-03-19T18:04:58.189782Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
+        2, \n      \"remove_star_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/remove_star\",
+        \n      \"replies_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/replies\",
+        \n      \"submissions_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions\",
+        \n      \"url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86\",
+        \n      \"uuid\": \"0755725e-5f7e-436a-be9e-8ac400953b86\"\n    }\n  ]\n}\n"}
+    headers:
+      Content-Length: ['5214']
+      Content-Type: [application/json]
+      Date: ['Tue, 19 Mar 2019 18:17:07 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1MzA0ODIyNiwiaWF0IjoxNTUzMDE5NDI2fQ.eyJpZCI6MX0.qO9kEj8hcA2p2_hGHde8ZGuu2PfvylxTYkoQpt8evvc]
       Connection: [keep-alive]
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
     uri: http://127.0.0.1:8081/api/v1/replies
   response:
-    body: {string: "{\n  \"replies\": [\n    {\n      \"filename\": \"3-concealed_straight-reply.gpg\",
+    body: {string: "{\n  \"replies\": [\n    {\n      \"filename\": \"3-seamed_betel-reply.gpg\",
         \n      \"is_deleted_by_source\": false, \n      \"journalist_username\":
-        \"journalist\", \n      \"journalist_uuid\": \"aa5b3342-edfa-4b4c-bf11-5a541b464184\",
-        \n      \"reply_url\": \"/api/v1/sources/9be62de0-f299-49c9-87bc-ebfa4632ee1b/replies/1a8708b0-485f-4f29-b884-daf5423670d1\",
-        \n      \"size\": 1116, \n      \"source_url\": \"/api/v1/sources/9be62de0-f299-49c9-87bc-ebfa4632ee1b\",
-        \n      \"uuid\": \"1a8708b0-485f-4f29-b884-daf5423670d1\"\n    }, \n    {\n
-        \     \"filename\": \"4-concealed_straight-reply.gpg\", \n      \"is_deleted_by_source\":
+        \"journalist\", \n      \"journalist_uuid\": \"63904448-542f-4f17-94c3-61d2f1bd0999\",
+        \n      \"reply_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/replies/9d43a86f-51f8-4b11-9d93-c5f7d924b0cc\",
+        \n      \"size\": 1134, \n      \"source_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce\",
+        \n      \"uuid\": \"9d43a86f-51f8-4b11-9d93-c5f7d924b0cc\"\n    }, \n    {\n
+        \     \"filename\": \"4-seamed_betel-reply.gpg\", \n      \"is_deleted_by_source\":
         false, \n      \"journalist_username\": \"journalist\", \n      \"journalist_uuid\":
-        \"aa5b3342-edfa-4b4c-bf11-5a541b464184\", \n      \"reply_url\": \"/api/v1/sources/9be62de0-f299-49c9-87bc-ebfa4632ee1b/replies/57aa044b-7714-4b58-b988-fe9f433c2b14\",
-        \n      \"size\": 1116, \n      \"source_url\": \"/api/v1/sources/9be62de0-f299-49c9-87bc-ebfa4632ee1b\",
-        \n      \"uuid\": \"57aa044b-7714-4b58-b988-fe9f433c2b14\"\n    }, \n    {\n
-        \     \"filename\": \"3-consecutive_effector-reply.gpg\", \n      \"is_deleted_by_source\":
+        \"63904448-542f-4f17-94c3-61d2f1bd0999\", \n      \"reply_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/replies/15114b75-e9eb-425d-8a80-1b0b42fa765b\",
+        \n      \"size\": 1134, \n      \"source_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce\",
+        \n      \"uuid\": \"15114b75-e9eb-425d-8a80-1b0b42fa765b\"\n    }, \n    {\n
+        \     \"filename\": \"3-exasperating_microscope-reply.gpg\", \n      \"is_deleted_by_source\":
         false, \n      \"journalist_username\": \"journalist\", \n      \"journalist_uuid\":
-        \"aa5b3342-edfa-4b4c-bf11-5a541b464184\", \n      \"reply_url\": \"/api/v1/sources/f9b8f60d-875c-4c7b-9012-daaba46bf074/replies/33d9b85f-83fb-410b-94d2-6a33939b2694\",
-        \n      \"size\": 1116, \n      \"source_url\": \"/api/v1/sources/f9b8f60d-875c-4c7b-9012-daaba46bf074\",
-        \n      \"uuid\": \"33d9b85f-83fb-410b-94d2-6a33939b2694\"\n    }, \n    {\n
-        \     \"filename\": \"4-consecutive_effector-reply.gpg\", \n      \"is_deleted_by_source\":
+        \"63904448-542f-4f17-94c3-61d2f1bd0999\", \n      \"reply_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/replies/b11e3bbf-c7e7-41d3-ba8c-ee56792bedd9\",
+        \n      \"size\": 1134, \n      \"source_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86\",
+        \n      \"uuid\": \"b11e3bbf-c7e7-41d3-ba8c-ee56792bedd9\"\n    }, \n    {\n
+        \     \"filename\": \"4-exasperating_microscope-reply.gpg\", \n      \"is_deleted_by_source\":
         false, \n      \"journalist_username\": \"journalist\", \n      \"journalist_uuid\":
-        \"aa5b3342-edfa-4b4c-bf11-5a541b464184\", \n      \"reply_url\": \"/api/v1/sources/f9b8f60d-875c-4c7b-9012-daaba46bf074/replies/d1bec437-a109-4df3-a710-b0812e40ac63\",
-        \n      \"size\": 1116, \n      \"source_url\": \"/api/v1/sources/f9b8f60d-875c-4c7b-9012-daaba46bf074\",
-        \n      \"uuid\": \"d1bec437-a109-4df3-a710-b0812e40ac63\"\n    }\n  ]\n}\n"}
+        \"63904448-542f-4f17-94c3-61d2f1bd0999\", \n      \"reply_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/replies/39818849-d051-4796-8a40-129212195891\",
+        \n      \"size\": 1134, \n      \"source_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86\",
+        \n      \"uuid\": \"39818849-d051-4796-8a40-129212195891\"\n    }\n  ]\n}\n"}
     headers:
-      Content-Length: ['1973']
+      Content-Length: ['1967']
       Content-Type: [application/json]
-      Date: ['Mon, 22 Oct 2018 23:03:39 GMT']
-      Server: [Werkzeug/0.14.1 Python/2.7.6]
-      Set-Cookie: [js=eyJleHBpcmVzIjp7IiBkIjoiVHVlLCAyMyBPY3QgMjAxOCAwMTowMzozOSBHTVQifX0.Dq_oyw.XbiV8NzpzDbPdFsmVRhX5v1mcNY;
-          HttpOnly; Path=/]
-      Vary: [Cookie]
+      Date: ['Tue, 19 Mar 2019 18:17:07 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
     status: {code: 200, message: OK}
 version: 1

--- a/data/test-get-all-submissions.yml
+++ b/data/test-get-all-submissions.yml
@@ -4,40 +4,37 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU0MDI3NjkxOCwiaWF0IjoxNTQwMjQ4MTE4fQ.eyJpZCI6MX0.fygpQy3CxB1ulUWLFz2UdrtcBKHz-fk5gyRxbcSY720]
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1MzA0NzYzOSwiaWF0IjoxNTUzMDE4ODM5fQ.eyJpZCI6MX0.zBrH3qVfk0ttGcMNVWYZMMOVARSQbuQMrIDUumzMXU4]
       Connection: [keep-alive]
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
     uri: http://127.0.0.1:8081/api/v1/submissions
   response:
-    body: {string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/0ec00900-64ab-4f76-8e09-faaf577e5633/submissions/32bbe523-9262-4fcd-a859-25c729b6dca5/download\",
-        \n      \"filename\": \"1-vibrational_sleep-msg.gpg\", \n      \"is_read\":
-        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/0ec00900-64ab-4f76-8e09-faaf577e5633\",
-        \n      \"submission_url\": \"/api/v1/sources/0ec00900-64ab-4f76-8e09-faaf577e5633/submissions/32bbe523-9262-4fcd-a859-25c729b6dca5\",
-        \n      \"uuid\": \"32bbe523-9262-4fcd-a859-25c729b6dca5\"\n    }, \n    {\n
-        \     \"download_url\": \"/api/v1/sources/0ec00900-64ab-4f76-8e09-faaf577e5633/submissions/18ee5d01-7ef9-4537-b868-3942557485ae/download\",
-        \n      \"filename\": \"2-vibrational_sleep-msg.gpg\", \n      \"is_read\":
-        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/0ec00900-64ab-4f76-8e09-faaf577e5633\",
-        \n      \"submission_url\": \"/api/v1/sources/0ec00900-64ab-4f76-8e09-faaf577e5633/submissions/18ee5d01-7ef9-4537-b868-3942557485ae\",
-        \n      \"uuid\": \"18ee5d01-7ef9-4537-b868-3942557485ae\"\n    }, \n    {\n
-        \     \"download_url\": \"/api/v1/sources/afc9f4af-1223-402d-bbe1-4cdd2b44a600/submissions/316ffed1-adf0-4361-ba23-45771c483063/download\",
-        \n      \"filename\": \"1-salty_intractability-msg.gpg\", \n      \"is_read\":
-        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/afc9f4af-1223-402d-bbe1-4cdd2b44a600\",
-        \n      \"submission_url\": \"/api/v1/sources/afc9f4af-1223-402d-bbe1-4cdd2b44a600/submissions/316ffed1-adf0-4361-ba23-45771c483063\",
-        \n      \"uuid\": \"316ffed1-adf0-4361-ba23-45771c483063\"\n    }, \n    {\n
-        \     \"download_url\": \"/api/v1/sources/afc9f4af-1223-402d-bbe1-4cdd2b44a600/submissions/69fba3ab-ea14-4ac8-98f1-e00d5c03476e/download\",
-        \n      \"filename\": \"2-salty_intractability-msg.gpg\", \n      \"is_read\":
-        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/afc9f4af-1223-402d-bbe1-4cdd2b44a600\",
-        \n      \"submission_url\": \"/api/v1/sources/afc9f4af-1223-402d-bbe1-4cdd2b44a600/submissions/69fba3ab-ea14-4ac8-98f1-e00d5c03476e\",
-        \n      \"uuid\": \"69fba3ab-ea14-4ac8-98f1-e00d5c03476e\"\n    }\n  ]\n}\n"}
+    body: {string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions/ae7e372b-21e5-4709-bb60-82ce5c6e13e3/download\",
+        \n      \"filename\": \"1-seamed_betel-msg.gpg\", \n      \"is_read\": false,
+        \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce\",
+        \n      \"submission_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions/ae7e372b-21e5-4709-bb60-82ce5c6e13e3\",
+        \n      \"uuid\": \"ae7e372b-21e5-4709-bb60-82ce5c6e13e3\"\n    }, \n    {\n
+        \     \"download_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions/f36c2b09-cbc3-4e14-aad3-a8b2c7d5fb80/download\",
+        \n      \"filename\": \"2-seamed_betel-msg.gpg\", \n      \"is_read\": false,
+        \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce\",
+        \n      \"submission_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions/f36c2b09-cbc3-4e14-aad3-a8b2c7d5fb80\",
+        \n      \"uuid\": \"f36c2b09-cbc3-4e14-aad3-a8b2c7d5fb80\"\n    }, \n    {\n
+        \     \"download_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions/75ff4e45-891d-41a5-bc83-ad162c03dcb7/download\",
+        \n      \"filename\": \"1-exasperating_microscope-msg.gpg\", \n      \"is_read\":
+        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86\",
+        \n      \"submission_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions/75ff4e45-891d-41a5-bc83-ad162c03dcb7\",
+        \n      \"uuid\": \"75ff4e45-891d-41a5-bc83-ad162c03dcb7\"\n    }, \n    {\n
+        \     \"download_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions/c0a5a4b0-8889-41d0-9380-fedd608b7e7d/download\",
+        \n      \"filename\": \"2-exasperating_microscope-msg.gpg\", \n      \"is_read\":
+        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86\",
+        \n      \"submission_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions/c0a5a4b0-8889-41d0-9380-fedd608b7e7d\",
+        \n      \"uuid\": \"c0a5a4b0-8889-41d0-9380-fedd608b7e7d\"\n    }\n  ]\n}\n"}
     headers:
-      Content-Length: ['2055']
+      Content-Length: ['2051']
       Content-Type: [application/json]
-      Date: ['Mon, 22 Oct 2018 22:46:49 GMT']
-      Server: [Werkzeug/0.14.1 Python/2.7.6]
-      Set-Cookie: [js=eyJleHBpcmVzIjp7IiBkIjoiVHVlLCAyMyBPY3QgMjAxOCAwMDo0Njo0OSBHTVQifX0.Dq_k2Q.DXePrrb4lUHEsHftmciBinEuKOQ;
-          HttpOnly; Path=/]
-      Vary: [Cookie]
+      Date: ['Tue, 19 Mar 2019 18:07:19 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
     status: {code: 200, message: OK}
 version: 1

--- a/data/test-get-all-submissions.yml
+++ b/data/test-get-all-submissions.yml
@@ -9,7 +9,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/submissions
+    uri: http://127.0.0.1:8081/api/v1/submissions
   response:
     body: {string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/0ec00900-64ab-4f76-8e09-faaf577e5633/submissions/32bbe523-9262-4fcd-a859-25c729b6dca5/download\",
         \n      \"filename\": \"1-vibrational_sleep-msg.gpg\", \n      \"is_read\":

--- a/data/test-get-current-user.yml
+++ b/data/test-get-current-user.yml
@@ -9,7 +9,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/user
+    uri: http://127.0.0.1:8081/api/v1/user
   response:
     body: {string: "{\n  \"is_admin\": true, \n  \"last_login\": \"2018-10-22T23:00:06.845751Z\",
         \n  \"username\": \"journalist\", \n  \"uuid\": \"16db39ec-0f92-4299-a15d-f6053b3d52a7\"\n}\n"}

--- a/data/test-get-replies-from-source.yml
+++ b/data/test-get-replies-from-source.yml
@@ -9,7 +9,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources
+    uri: http://127.0.0.1:8081/api/v1/sources
   response:
     body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/1f2f6b0e-a152-4ae1-92aa-7e9953ee9db4/add_star\",
         \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
@@ -52,7 +52,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources/1f2f6b0e-a152-4ae1-92aa-7e9953ee9db4/replies
+    uri: http://127.0.0.1:8081/api/v1/sources/1f2f6b0e-a152-4ae1-92aa-7e9953ee9db4/replies
   response:
     body: {string: "{\n  \"replies\": [\n    {\n      \"filename\": \"3-make-believe_pharmacist-reply.gpg\",
         \n      \"is_deleted_by_source\": false, \n      \"journalist_username\":

--- a/data/test-get-replies-from-source.yml
+++ b/data/test-get-replies-from-source.yml
@@ -4,74 +4,68 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU0MDI3NjkxOCwiaWF0IjoxNTQwMjQ4MTE4fQ.eyJpZCI6MX0.fygpQy3CxB1ulUWLFz2UdrtcBKHz-fk5gyRxbcSY720]
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1MzA0ODI1NiwiaWF0IjoxNTUzMDE5NDU2fQ.eyJpZCI6MX0.HOWcVss7bM9KuFyqW5OmSX4G-pwH7P4KKWU_nqytS3E]
       Connection: [keep-alive]
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
     uri: http://127.0.0.1:8081/api/v1/sources
   response:
-    body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/1f2f6b0e-a152-4ae1-92aa-7e9953ee9db4/add_star\",
+    body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/add_star\",
         \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
-        false, \n      \"journalist_designation\": \"make-believe pharmacist\", \n
-        \     \"key\": {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFvOVwsBEADeySdQaMkRqff0/5Giry2iGDG61kbrUOmP2mb0QbfKc304Iilz\\nurxQfnfv5TVw4UJvGG07Va9l3cXyvh+Y1CVpV8NePOvi2PaUcAh8es2jRNKWuD5P\\nyyoxf7w2FRZgtG6pRH3gyg6Jy0sO4EOHzn6bA/Jjq+RVbR0MlTaKrEb2CE/qnQdY\\nAjT7PlC5styI5tARQNsEAJh+en6Mt+OS/cowK5PBDk6BfetSfbTtoR7HAZV3In3N\\nQtAheip6OVjRNMtl4smhT5zbB/A6wxBZGOWQLET9lTF5/EfM8Q6Or+/R+R4q5QbU\\nSESHhw4bhkFl9NIOfHTgJGl2Aq4crPOCh29ZGb8QQJBYHK3b+ddSn05kAwd1J4Sn\\nrvL0hhwdwu2bimyHa2y28S9EMOAd+XC6RequuFQsrwvxgd4KnHBm9ZZ7OAGsYmNL\\n/GtFiu7BMP04KOFLwNQHqV6Fg1M2skoT7WjU9HIaFii3kV64oY/mecfqfZslLENN\\nTVgayeMZ3YI6D0m1xv11b9nnbMFToaatH+VRQniXeI4P8GFBeEYcnjeLyWD9O/i0\\nj49lBAVK1ajxRI3rXMzIcnqLzSy+noe4XaWb+KEq1OzJ8XR6nV2PJ6wGmNkugW3I\\nKctKZy/EA9Pyx7zPPvY4zUKMRCZmDEKl4+ewSu2oHpqkO8s2UHgzi5l96wARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8Q1E1TlVGSzY0NE1MNkIzS1lCN1pYT1BZQ1c1\\nVFhLQlFMQzNJV0ZKNTJEWUpXMzNMWEVQSFVGVk1BNUZFU1VYWlBPTk9NSk0zUzZC\\nSlYzRTdZU0VSUE5PWVFBV1RFNExEQ0RRQTRaWT0+iQI/BBMBCgApBQJbzlcLAhsv\\nBQkB4Jg1BwsJCAcDAgEGFQgCCQoLBBYCAwECHgECF4AACgkQ0HbT1Onm8LWHIRAA\\nysZLcVJEpIdQTIQC0uPawGhFjixTatv7wHp7Awm2leb/ZchV+BwWM62QYL0T7G+Q\\n95IwU/Qoi6HaAm/JkRN2Y6C7SAieaT/3VqtkVjoZdxMpPjdg/m0vbRPzOBTy6vIX\\nzxFzUoYJafiFIGOLJQABrcj4jGT0c4kQRTW020ksO4h1S61Jqjz0jBK7Pab5pS2H\\n9hEiqGRVJdtiw7m5d+PclE7m4fA8bfRdW76uCPsuo1BWD7uoWTrZChE9yoDzDzMf\\n6aTVe1oRCLWlYtD33FiMUGVJBq5mqSH0qIO5TZtMQPm6273ExhmsWR47qxO6BXl/\\nN2lfb6P/pbW3LmvsfEaL2hlsq/CQTiASA3jcsfr6N1YnQUmQ/asNLAUDuZWTAyGL\\nu8gZ5CgYkmPi86j5U2KZVRfKBAvO4GedSIEOWzYlVh7hqei0w6yVm+G7FK0ztoWt\\n1JcjAVQEO2+mRvD9MHqlQPMOlIFK6BN8PQlTafqddbzyriAeCtUUE7VScN+Yqm2j\\nbZhmy5wo52oJtuRX92c9y9HThtGwWpGT1OezlQxAgH4Tktws7lUFO1QWg4fOYzjH\\nKFN/mbNDbsNuaLl0wpBxk4NDEa057EYE8vB7ogu0HqxJcZ4wr+VrDpqdP8uxu2y0\\nWNybvKNtGtcZ9lDYuCbOgZH2DI2n4q/pMcIx7ODG+6A=\\n=zN9o\\n-----END
+        false, \n      \"journalist_designation\": \"seamed betel\", \n      \"key\":
+        {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFGRfoABEADb9T/kz6wfGMdHgRyl0VqXmolVe2ll6m2ULXQMJ0F75OmgEMqX\\nQS7JF/GoyPUWfAr3KW5t1f909w29GKfOHcel48pTXwIjpBeYXkwgV/wQQ7l8jj1g\\nII/jv0EP5a8/DiP5tRjQ8/mO0wSdzZU9nWEdohvkHwvTuxjpUtiN8/qqo8cQU1uf\\n78Psnsb3SEP5J5debt/TfEaTg7YdEnTUo50WMVksp6tVyl4vsE7Pi/Rt46+Ww/Cx\\nGfVjI8YxZR7/CGft6IW6pJIIymwnaVotFOd0gZGoj+kvA3D31uHO+2JYpA2G8oQj\\n6Url/60zSh6IjBy5suV+ioP6LnjOlvi2KQjtHwzckxxIsv/CzJvcPUK4j4k8Jwuv\\nmyT6s7BFteY8dqyGbwaF75zh2OFno7YtHKtw+ktWG/zRUKHL31ztA+dukMOfNj1y\\nkUoNQjUz5yUKhhxCM7mS+8AGv6qWH9wRcewpqxG97YxBWGVtSs742sGShrzrLuP4\\nUtrmSd95CSxLe5RXbSbqWpBZ0Bm6fcTv1gw6R1exfQyIbdOS/lfC+HnnsWBRFgX9\\nKjQ3d253wDTe5X30FYRGvuxE2zyAczOuki4ZFYszViwGWH81xvjv8Iv/ypwgsua+\\nRc1SPIpC4EI38+N4hclbprv92x6CS+xlDGl12XK6kWE2v9ZqW95xX4sCzwARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8SFRERFo2UElZTEU3U0RGWVRDN1FQM1BNTklB\\nVEI1WFRFUExOUVFMTEpKV05QQ0lZV1paUlE3R05KWTJPRzVCTEFXMlo1NExQVkdO\\nNVNaWFdURkVXSExFS0pIVEZKSUpMNk9BUFlWUT0+iQI3BBMBCgAhBQJRkX6AAhsv\\nBQsJCAcCBhUICQoLAgQWAgMBAh4BAheAAAoJEEtk3eaziePUQ1cQAMg52/7/qN9t\\nkD7Qdb2X1Bpz+ZSHpWqqPpLWCWXwanZALFXommqTOxDHrsZahwaO4YkW1HsNzC9K\\nwdzhKeQfmtE8NBY53nKzdeLJ5HDFq9daa2CDzIwjiCWG7RC9cMYGxuI9RzvMPMxt\\nusHmR2HV+SCipMp+3mAyUaStkqWyeDHZBqPSw2zFy+sJ4t418yl4pf64eu1zKB7x\\nhpyMnoiSx0wYqwLlfSipDdk4+13eVjJgiIjPxmJYfkMRFEAZVVOPUXsNHUSV83OT\\nybnX4nE9+JlwQFrqgg8uLNyEJh+10WYO37Dt4gKy5iR2rJ316ANxe+g41Lxwz+VA\\nDgrJl/OpfhMqf3epwerzPnhqfpn6NgasyNdx+iHr/Z45jLSdGos89mJ3QJwcbjSi\\nwlDSNnMLtFmuxb1wtx9uaIcCIsIbqGAuaMiq7QDHdktp37cqfdCdS2RTGwqibz0V\\n/cWmHuF1r5jwUPUEGpXCaP6eI4J2zBG11BB7xLKwJmIPbrQuDScCinxmpQVN+BIy\\nSG9j4sd1z2CXKr3dyf++tyPol4+QTweTbpSxE+tOeokI3g9Pv/UqBc/lvmAqPJUR\\nvaq8HKGwHWe03mf6bH5CoXb76QlWVB7SbLju0Zct7B2Tt9+pDea5aivqMQJ78VPu\\nS4uu4UfPHvQU+V2sVvOsT127PyhysBvM\\n=n7gc\\n-----END
         PGP PUBLIC KEY BLOCK-----\\n\", \n        \"type\": \"PGP\"\n      }, \n      \"last_updated\":
-        \"2018-10-22T23:02:37.971245Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
-        2, \n      \"remove_star_url\": \"/api/v1/sources/1f2f6b0e-a152-4ae1-92aa-7e9953ee9db4/remove_star\",
-        \n      \"replies_url\": \"/api/v1/sources/1f2f6b0e-a152-4ae1-92aa-7e9953ee9db4/replies\",
-        \n      \"submissions_url\": \"/api/v1/sources/1f2f6b0e-a152-4ae1-92aa-7e9953ee9db4/submissions\",
-        \n      \"url\": \"/api/v1/sources/1f2f6b0e-a152-4ae1-92aa-7e9953ee9db4\",
-        \n      \"uuid\": \"1f2f6b0e-a152-4ae1-92aa-7e9953ee9db4\"\n    }, \n    {\n
-        \     \"add_star_url\": \"/api/v1/sources/da9e4d3d-e8e9-48ee-9d19-e2734c7ae995/add_star\",
+        \"2019-03-19T18:04:56.323543Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
+        0, \n      \"remove_star_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/remove_star\",
+        \n      \"replies_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/replies\",
+        \n      \"submissions_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions\",
+        \n      \"url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce\",
+        \n      \"uuid\": \"56208324-861b-4d2b-ac4e-555d516f24ce\"\n    }, \n    {\n
+        \     \"add_star_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/add_star\",
         \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
-        false, \n      \"journalist_designation\": \"hilarious climatology\", \n      \"key\":
-        {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFvOVw8BEACnnCfkrVt/TP9N6Xaoyo//yJG0ZGV0i4XB7uKe7QnwiP/QXZJc\\nMNsnll0d+r5hKYNMXoAY2Bqp79241GcWnkZSje9TRtfU8hXtsfBDTtnu8NJqBVfz\\nEozDNPumhkje6biDPFkfde3FfLB6uZYdoyhG8htvudhfUjTDyacTkqcIyJBNhdtf\\ngMunbIz8hwJVW0h95Hu4HH6RDludDUdr8gEOIQm4JiX1l4iecpisDuXpLLFwsM1C\\n02qyyk9Byhp3IQFeJ+ErQwQ2lCZ7MGmHo0/qgTXLIQzkSYCJCAcqtUjc1bYwkfS2\\nKKp5i6hX6+6znLpwIdY2Y7OXN+CS4N5k7eLedybbqH0vnxsrIAWgOOfFPza1i/CS\\nRE7uAUu3adxBziGqfe6lAti1LhYd0iyfa1cGOQdl8xuudWNHdKODrTDyne2TLKKx\\nIBrSaC86N0AZxEaH0VBR4ICuywNBdn4hp11WrVmqXqR1MLSzxgK1xwpFDDKw0JOO\\nkv4Crbl0jhHKiIqCbqmrq3mN+Ut5CM6zI5CY0y/ASpDSkbOCNiMEFJ+9d8lROOiU\\n5NabIyRIazI3YMbX7TzNCz8ikJP7GDtzHC3MVHzIqNbxgR8x9tDYPJeaFxQxI2+j\\nOVS6ZiWtuZw6x/yuPUicfJM8fNTouTIm0ZEg/igWEhm4RY7jy+IRjFuTfwARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8NUVONVNGVVVDU0lVQ1NJUFpTTEpHNVQ3NFcz\\nVlhRSDdCTUNUUEJRTlRTUDJKN1c0UzM0S01LSEZEWVg1WEJJWVpQSVg3S1dRVzRF\\nU0hWNVoyMlRXV0tMNTI1SDRDQ1hUUllST0NXQT0+iQI/BBMBCgApBQJbzlcPAhsv\\nBQkB4JgxBwsJCAcDAgEGFQgCCQoLBBYCAwECHgECF4AACgkQ9d3404sMUL4NHA/+\\nKJbZUj0pwOWEkGsj0FpkX90hG+cMrLUDp4NtV2cMBJd2nYb7kFwhcQ1kHkjZE2n5\\n6uDhc3wkVlUUnNzZzvUW1gFiXPme02Sg9jSqNTSJKFobujfn47pMSq1BKVIJi+cG\\nxqKz544Rfl/LRuekeChtXB/Jpzfactc5eKzfJI0EyvSLpRrSdK8brLy2zQI1YwK4\\n2RjbXJ/ygOH3fqoUdeKX3/6HvApww6uBjL/Wu9yIYsFFcvw3oTezGYdyMf/5E3ic\\nJBw1cZLF2v4qEvRuKkJlhBAjHtcg+JDguPBoEqD+FmzAWpvj0Sz+pfA2YZeHtN7l\\nAWhQpKEN/sofLZCNVOgXSm2+rV098ssE6Q8W/fouV/AHgy/pkCfyKy+NCKXfm+d+\\nsQuC2SyBCgYPjkfZsERSwwuu1eRauB65/VsckTYiDryeaESDeOwRipgrcko7sYO8\\nULh0gQCzwzRlCiYQTw3m6BxQW+KCzewhRNBTO3iAaTQf7SzlpBLivDAanu65vZMg\\n9D9ayVKS1gKzI6X6heBDQ1tK0Xdv/TkKGJl1HH+SBSCVI4YyZQzi7ft8U4o7qCda\\n9nO53VYA8KcBErvM05Sn0WUOpVfL51BP1Pk14MdpE9Yb6q4SLdiS3OQRuUivm6NK\\nIF/t/xYEBmE7Qrynzup84rRoOU1KHmKz2CC8p3kS/cg=\\n=VILh\\n-----END
+        false, \n      \"journalist_designation\": \"exasperating microscope\", \n
+        \     \"key\": {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFGRfoABEADKFFsV9PHRYbM9Dk4sDphjk/g8GEJky4kUzZwsD/Z/8DMRYJZw\\nJlkevyBDw5pZr/NhLtGOf085jSwG6O6nr7QTuJOI7Szh2Ib0r30jJwfL1LdWj/6N\\nf4iXVHzk817NSd//c2V7Qu59opHrxIUntfgiIEjj29EgpnoWWuJ4pe4gvfz/WS2G\\nKPPzFVm9CfZ8xc4YBl2l+rP1AIL+LdIWzcTq+/Y7f7nMdOsKYgaHnmjqZ1EIu0R9\\nR40hBDiqTpeoDhn7mwVG2N2Z+hxqHLxstr2m+o66p6xbo5yeWn/rQATueyd0lt/+\\nD/szhl78657zIYuVFMflQibbMz8hPubFVqEv2tiAp9Ul1sZfUPYr0bBjAXzMYllP\\nZDflpJF5AlDTNOr20zsAHUW8fYnm/YiPvM5Gjz9QfRTpa9C6yHceqk75Cr0AKB+q\\nhIQrt7B/J9EMOdkRyERZBewu4DcUHP+pRES+2at1C6d6Qunp6QQPcfILfJS6Bp3H\\nY4tbNl7neqhPQu/GsDD1CDoOiclOgLHUBnDH9ef80jGoCffO3qQDzckQ8S0xrORs\\nxaa6YSsj2u8XL7QbDe0WUFrypUE0Y/4kETw27qtH5xBISHcJbO5tLDllEHCJxAvX\\nNyIv6YvcpNXCh/F2dLP2x1vRt2xayLD5Xd+T/xtCaMdMWJiYu1Qj65uIMQARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8T1lLRVdSNERKQ1EyTTRYWE5LNjMyNVAzU1pU\\nUkxQM1BBR09ZR01MWVBYTDdIWVpPVTRYRkFMSlFKNzJTQlJaTllRUE5CR0dJNlJX\\nVFdGUlhHS1hUUUtCN0VKNEE1UUI0MlpBUDNEST0+iQI3BBMBCgAhBQJRkX6AAhsv\\nBQsJCAcCBhUICQoLAgQWAgMBAh4BAheAAAoJEFOrutu9FeYMFFEP/22xHEk1Z4jB\\nXxSE7p8hWLaqJgD2BaSOBvqKU5hba91E/RvpTsGjbpmCaHlfLGL8haUQpSFxTW7o\\nR7kiVFdZYjuRCOoOITuH0P2vtVC0VE4/uE3MWF5UWgXeVp5SQz67kgtn9MBV4ZYK\\n1P6cRfZgHfLUsFtEP/U2Z6DjGe580GR9SivCbU2XC3rvcURjZqdvFkT7ABIgjME7\\n4ee0XCFs7oYnzXKZcY9ADrBTTt0d1c9FobavKKJwYs76ZF71WmkfcVEgTaT2DBg+\\nbpAz/3zSX6xSMFUu/VIQ7+iQYstTx/Un9VmV9BnnqwbMeennmQDpc9xC+80kvawD\\nsybSVogVMyjpCweCLYXiP/I1XDu2J3WZIQ1p701fgBvRp4SsPwXWJtE5j2DTQDq6\\noIh9bssdHu8hw0BHXkdprjHRij5Uek8evjbzz9gflat6Vlk2deq7KovFN6nR7xTE\\ngt2XBSoluUlVINN5ozgw/Il5tqDaZDv32hzU7wUmBeQPHvyrm6i9IhiOOTgQr7Wi\\n3DBrUpdXZZNxiKMEoLdAw7VJVXuvCEXELtQBfCoIbuGW7jdWeA+k8C9pxCrOG6O8\\ndNDP33U21/+N9XyMHBCF4TMiLJhhrcvV8/LtJ1t0id3oRm54iwuKel6KL0NQoIE4\\n5tICW7cN9qFg3719pl+SE+t2MqXqoaWO\\n=E8/J\\n-----END
         PGP PUBLIC KEY BLOCK-----\\n\", \n        \"type\": \"PGP\"\n      }, \n      \"last_updated\":
-        \"2018-10-22T23:02:40.707390Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
-        2, \n      \"remove_star_url\": \"/api/v1/sources/da9e4d3d-e8e9-48ee-9d19-e2734c7ae995/remove_star\",
-        \n      \"replies_url\": \"/api/v1/sources/da9e4d3d-e8e9-48ee-9d19-e2734c7ae995/replies\",
-        \n      \"submissions_url\": \"/api/v1/sources/da9e4d3d-e8e9-48ee-9d19-e2734c7ae995/submissions\",
-        \n      \"url\": \"/api/v1/sources/da9e4d3d-e8e9-48ee-9d19-e2734c7ae995\",
-        \n      \"uuid\": \"da9e4d3d-e8e9-48ee-9d19-e2734c7ae995\"\n    }\n  ]\n}\n"}
+        \"2019-03-19T18:04:58.189782Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
+        2, \n      \"remove_star_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/remove_star\",
+        \n      \"replies_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/replies\",
+        \n      \"submissions_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions\",
+        \n      \"url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86\",
+        \n      \"uuid\": \"0755725e-5f7e-436a-be9e-8ac400953b86\"\n    }\n  ]\n}\n"}
     headers:
-      Content-Length: ['5247']
+      Content-Length: ['5214']
       Content-Type: [application/json]
-      Date: ['Mon, 22 Oct 2018 23:02:44 GMT']
-      Server: [Werkzeug/0.14.1 Python/2.7.6]
-      Set-Cookie: [js=eyJleHBpcmVzIjp7IiBkIjoiVHVlLCAyMyBPY3QgMjAxOCAwMTowMjo0NCBHTVQifX0.Dq_olA.wX1oQ3GIdHyPm51slPeirKT84YQ;
-          HttpOnly; Path=/]
-      Vary: [Cookie]
+      Date: ['Tue, 19 Mar 2019 18:17:36 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU0MDI3NjkxOCwiaWF0IjoxNTQwMjQ4MTE4fQ.eyJpZCI6MX0.fygpQy3CxB1ulUWLFz2UdrtcBKHz-fk5gyRxbcSY720]
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1MzA0ODI1NiwiaWF0IjoxNTUzMDE5NDU2fQ.eyJpZCI6MX0.HOWcVss7bM9KuFyqW5OmSX4G-pwH7P4KKWU_nqytS3E]
       Connection: [keep-alive]
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://127.0.0.1:8081/api/v1/sources/1f2f6b0e-a152-4ae1-92aa-7e9953ee9db4/replies
+    uri: http://127.0.0.1:8081/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/replies
   response:
-    body: {string: "{\n  \"replies\": [\n    {\n      \"filename\": \"3-make-believe_pharmacist-reply.gpg\",
+    body: {string: "{\n  \"replies\": [\n    {\n      \"filename\": \"3-seamed_betel-reply.gpg\",
         \n      \"is_deleted_by_source\": false, \n      \"journalist_username\":
-        \"journalist\", \n      \"journalist_uuid\": \"27237818-5cec-4ee7-989e-0183f710bfea\",
-        \n      \"reply_url\": \"/api/v1/sources/1f2f6b0e-a152-4ae1-92aa-7e9953ee9db4/replies/97e42dd4-a493-4e03-ab42-8e7aba16e88e\",
-        \n      \"size\": 1116, \n      \"source_url\": \"/api/v1/sources/1f2f6b0e-a152-4ae1-92aa-7e9953ee9db4\",
-        \n      \"uuid\": \"97e42dd4-a493-4e03-ab42-8e7aba16e88e\"\n    }, \n    {\n
-        \     \"filename\": \"4-make-believe_pharmacist-reply.gpg\", \n      \"is_deleted_by_source\":
+        \"journalist\", \n      \"journalist_uuid\": \"63904448-542f-4f17-94c3-61d2f1bd0999\",
+        \n      \"reply_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/replies/9d43a86f-51f8-4b11-9d93-c5f7d924b0cc\",
+        \n      \"size\": 1134, \n      \"source_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce\",
+        \n      \"uuid\": \"9d43a86f-51f8-4b11-9d93-c5f7d924b0cc\"\n    }, \n    {\n
+        \     \"filename\": \"4-seamed_betel-reply.gpg\", \n      \"is_deleted_by_source\":
         false, \n      \"journalist_username\": \"journalist\", \n      \"journalist_uuid\":
-        \"27237818-5cec-4ee7-989e-0183f710bfea\", \n      \"reply_url\": \"/api/v1/sources/1f2f6b0e-a152-4ae1-92aa-7e9953ee9db4/replies/4fd4ea5c-3eba-474a-a5f1-a4891489a994\",
-        \n      \"size\": 1116, \n      \"source_url\": \"/api/v1/sources/1f2f6b0e-a152-4ae1-92aa-7e9953ee9db4\",
-        \n      \"uuid\": \"4fd4ea5c-3eba-474a-a5f1-a4891489a994\"\n    }\n  ]\n}\n"}
+        \"63904448-542f-4f17-94c3-61d2f1bd0999\", \n      \"reply_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/replies/15114b75-e9eb-425d-8a80-1b0b42fa765b\",
+        \n      \"size\": 1134, \n      \"source_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce\",
+        \n      \"uuid\": \"15114b75-e9eb-425d-8a80-1b0b42fa765b\"\n    }\n  ]\n}\n"}
     headers:
-      Content-Length: ['1005']
+      Content-Length: ['983']
       Content-Type: [application/json]
-      Date: ['Mon, 22 Oct 2018 23:02:44 GMT']
-      Server: [Werkzeug/0.14.1 Python/2.7.6]
-      Set-Cookie: [js=eyJleHBpcmVzIjp7IiBkIjoiVHVlLCAyMyBPY3QgMjAxOCAwMTowMjo0NCBHTVQifX0.Dq_olA.wX1oQ3GIdHyPm51slPeirKT84YQ;
-          HttpOnly; Path=/]
-      Vary: [Cookie]
+      Date: ['Tue, 19 Mar 2019 18:17:36 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
     status: {code: 200, message: OK}
 version: 1

--- a/data/test-get-reply-from-source.yml
+++ b/data/test-get-reply-from-source.yml
@@ -9,7 +9,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources
+    uri: http://127.0.0.1:8081/api/v1/sources
   response:
     body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/562bc2f3-6c23-4168-8218-be8309463bd1/add_star\",
         \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
@@ -52,7 +52,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources/562bc2f3-6c23-4168-8218-be8309463bd1/replies
+    uri: http://127.0.0.1:8081/api/v1/sources/562bc2f3-6c23-4168-8218-be8309463bd1/replies
   response:
     body: {string: "{\n  \"replies\": [\n    {\n      \"filename\": \"3-unabated_dysphagia-reply.gpg\",
         \n      \"is_deleted_by_source\": false, \n      \"journalist_username\":
@@ -84,7 +84,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources/562bc2f3-6c23-4168-8218-be8309463bd1/replies/c6cb5121-3585-4587-99de-7c82a46cc74e
+    uri: http://127.0.0.1:8081/api/v1/sources/562bc2f3-6c23-4168-8218-be8309463bd1/replies/c6cb5121-3585-4587-99de-7c82a46cc74e
   response:
     body: {string: "{\n  \"filename\": \"3-unabated_dysphagia-reply.gpg\", \n  \"is_deleted_by_source\":
         false, \n  \"journalist_username\": \"journalist\", \n  \"journalist_uuid\":

--- a/data/test-get-single-source.yml
+++ b/data/test-get-single-source.yml
@@ -9,7 +9,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources
+    uri: http://127.0.0.1:8081/api/v1/sources
   response:
     body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/a2c25dff-cecb-4194-95b8-8a1cae5c86fc/add_star\",
         \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
@@ -52,7 +52,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources/a2c25dff-cecb-4194-95b8-8a1cae5c86fc
+    uri: http://127.0.0.1:8081/api/v1/sources/a2c25dff-cecb-4194-95b8-8a1cae5c86fc
   response:
     body: {string: "{\n  \"add_star_url\": \"/api/v1/sources/a2c25dff-cecb-4194-95b8-8a1cae5c86fc/add_star\",
         \n  \"interaction_count\": 4, \n  \"is_flagged\": false, \n  \"is_starred\":

--- a/data/test-get-sources.yml
+++ b/data/test-get-sources.yml
@@ -9,7 +9,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources
+    uri: http://127.0.0.1:8081/api/v1/sources
   response:
     body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/c7abe6eb-e9f6-4bea-9d82-740ffcf833b0/add_star\",
         \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":

--- a/data/test-get-sources.yml
+++ b/data/test-get-sources.yml
@@ -4,42 +4,39 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU0MDI3NjkxOCwiaWF0IjoxNTQwMjQ4MTE4fQ.eyJpZCI6MX0.fygpQy3CxB1ulUWLFz2UdrtcBKHz-fk5gyRxbcSY720]
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1MzA0ODMzMywiaWF0IjoxNTUzMDE5NTMzfQ.eyJpZCI6MX0.ddYrDcarObwI5eqbYKHslN1MGzpb1LVIfrLByLuZyfk]
       Connection: [keep-alive]
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
     uri: http://127.0.0.1:8081/api/v1/sources
   response:
-    body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/c7abe6eb-e9f6-4bea-9d82-740ffcf833b0/add_star\",
+    body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/14738aa1-b256-4049-8f89-8c97e77d6b82/add_star\",
         \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
-        false, \n      \"journalist_designation\": \"disgruntled grasshopper\", \n
-        \     \"key\": {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFvOUiQBEACbAiwRG/qz8uikq1HLlrwoeGy142rnvuxURse3/C8q7f2z1/yX\\np/wuoHGRyucfGyl33Qa5rocyxJeK+/Vpvn6GC6j5KQVmnodVbzoIR6AOyJSFwVFE\\nxuwzlZJFhlk/U6LNYDrm3M2Nb19T+h5NaH1Lw/s2DfDRzmqv15Gs8K+HsVtRPOV8\\njY7AvA/u7zffh8/X7eYP/RQCww/QKfVzAtVDo6oXlRO/q5VhIYYwrQUPkju0vru7\\nVZGwkCQxiubi0BkpicaQeCX136Zxh38m1b9dERvJWxgzCJvOjumEUrPytgFlOGIJ\\nSBex+xnl3IPPO9Q63TBS6Et3Qi219y+et1QGKr1xiRvmUVA0H/nn1tVz2oD+WVfO\\nDZ71nhIhYjuRZYw37MlQb7Ivgdkrj9n0zSXBXxCXuNHCk2/VQn0SpND6vnQMQp5r\\nF5sO9PAlPpDcEjOyqic25Bn/wkCxJPLR90Fybc6K23w76B5Cx9cOdVsT9yeycwOS\\niBw3HGc7MDagTXnYBDNMW61D51eH/Fdi9fZ4MtcdfBNRweV/Js/rD9DIK/mwyiwQ\\nWh/RG9vkvx9Qoa7ykcT3wN4gQh4H5M5HyGHpOgYiXYVcNfuTo6TF1QOML7o/ptEa\\nafGSEbBdIE9ILVy263DdNqktjBFKUb6GJGpXakCSrmubWrXek2llkkwKqQARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8WVJRSTNDNFpOSjdTWjRIUVlXSjJCSTVYU0JG\\nUk5FQUY2Nzc2V09VNkxXWFRVUlBaSVhFVVZNQ082WjdCRlU2WlZPVURLV1VYQlRK\\nWkhUWFpMTUJCM09YU1A3SFJIWEhWWElRSkNNQT0+iQI/BBMBCgApBQJbzlIkAhsv\\nBQkB4J0cBwsJCAcDAgEGFQgCCQoLBBYCAwECHgECF4AACgkQPwX94hLOzsSNPxAA\\nkcWWQKz/ehr0KVOibxUz+YgdAPshbsACFfMWv2A5MlmilWkl+lUWGaplmJEscybr\\nuW09ZJMIu+HJ8tevCA0vKwEVFBwqx6YmT2Bz0KkcENKaBXhK/MJg77A2d8LLHzGD\\nWSjCFU4EnG0UF8eCD4k2U5jox22GkmwbbU8HOSNZrQooBK5mAIgYAdn46Z/FRanP\\nkfjiSeTzd4Z6f7qPyrR5tmvYSQEcoLZSIyY9FAiN84kV6CKvJwAQXgiwYeHvvaBI\\nR9YmHULq9R9Na7PzykJo7QkxsR4sWsChz5yA6NAZk7nR6ktZWk51MAQhoe+INM7O\\nvZLt6508H0dxHZ2WZ/otX3WO0qLU6AOpddlPP0qP90hYOmVlpb9l4bGjbED2D858\\nykZokJ+TIp/AMRB10LiYeGlBxauR4HeXDQ4gDinmZkNfOhffOYS3fIouOpK5SSEI\\nHenXccDE8OmRYI7d6KpuRiZSC/203HM1jQV3UaVnTAfUs73pu72jz/A76NjWq+Sl\\nV2KZpqxfO/umqXZ94zlxQSyatNuoQ9JBzXM9/pgtg0e23o+0c19sr6PcXja/Bt8a\\nf1qemG7w9pGAfYn4zJJVUUYWEWBEWCYYSk0feBQRK647nBZ/vWPnExVeXK1oz8cB\\ngVbcU2KMRdXDCHgVEBgy/7BpF+Gd50VB4SbdO8A9XH4=\\n=J0A0\\n-----END
+        false, \n      \"journalist_designation\": \"polycrystalline belch\", \n      \"key\":
+        {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFGRfoABEAC5C3SwDH5xGvby2ByI8XBtzUtExsXWq4BJA8agVtjWtc5h8ChI\\nYLkJVv3yOdokpJhaOHPEI/FkoiTv9yGrcS7RGItCDYMWQelB9LhOWU/nNwJgWAKH\\nGdf0951TcTzf1FsfeXtmNhfZlpnoaPegdp6qHSEp7rL9AzbhiGmDEi5esN74NZST\\nSwYTMOgOfNOPOkByerdjVSxWkPFelI4GBzfRP7+bvqjguSrQQaTeW3buSZw5ZjuW\\nVnIt5F21Hn6hwspJJXAxqO9MjKkUjtQMz6R6bTnTC13KO8cdYINsLNXYl/VSde4C\\nQ4VKb00+FT3zyzBnF50Uf76eDJoohiJ7OWxzd2mN7nPdnKxwoGV2WlSO9x64YtZU\\nyHqGM3sb90Mhu9VvACBq/UNUNsTtriXbN9NETMJtMp4CNRuaDraK1nbDW4IF27yk\\nHpAap2kA9gx1MrxwaGpradBffUbfolZPagFvIfN4Z6CKJ8DZ/ykgGZm7K75Q+60b\\n0KrWBOviBYAI4j6/AsqCTEAz6X9W0oEMcWdL3wISLzLQgGd/cLXFvBHxUsAqsroW\\niBb5DdYs0gOoEY7zfBFNt1U1zNin1qCftfn8lf9+eOvCqjeXTqSKwzXg0+ffyauL\\nY49XqTrpkR4NKZxFfpkZ3BYjD91BGdijzZM6B6BJQxclXxFPrZECWAP+4QARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8TlRIQkpDVklaWlFCV1lTREo3T1lCRTNWRTVT\\nNkhZSUVUVk1BWUFFM1hLVkJZRkc0UTdIWVdNS1NVTEJRMjQyR1hVV0xPTDVFS0dU\\nWFUzVlVJUUJPRjYzRDRZNEJFVUNRN1VMRkxGUT0+iQI3BBMBCgAhBQJRkX6AAhsv\\nBQsJCAcCBhUICQoLAgQWAgMBAh4BAheAAAoJEMO0d7F1N2cEgdAP/AmVvya7+M4F\\ncU6YFpeBJshGQ1Zikpye+Qp/YoiDsuZuQfYk1SsI+bWATRz8Wp/Q1Z0U/w5DVyyJ\\nD3Bx/g4+0z0jzDFbZ3srqlNoUmA+JKUmARQAvGpRyCYuFat0Xi2P6dKeLlGXM5/c\\nD8l5Te0kSbHizCD12BOWNoyiB/Txjs9Py4R/rbCMGubhWxlPoqQ/+vbL4rYvnDXs\\ng/UW3PTVFMwG21PuG6vrcIhoJGsCISL3equgYFjdBA4Anl787ARr8mpc8oxZg0P8\\nJJe0Er4UfNh+fnQmyNouP7PqsQNB978Im3fGGchMhgpy7QNwGA5NPFmlL7J8HV9N\\nhix0J0cy70N/YXobfiISQvQ7oVDE06udPSiEJvP4VVdWr191nv525z0rubvdIOYR\\n22nZpu6qZXV/DmpACrCccjrzUc2S+CjKNp9FquxxcHGEZC88H5devLmOApnXwi+1\\npuTYgWuQfp56KXXrvOq5JfXa/z36bgiWhuzWE8ZeoPj4gKr6vnWVpgV1LjASRDs4\\n3+LI8GhEUThQvNgVX9LkzZCdYRMA6lmpJb0c2sjtR6ogSh1eRb+bVD/Xx+fnqBjG\\nv7FbysXda6Zf5M/44Xlqu4/V3CiMulkavaRZMIvOXUbZGQc4mRXDP09l7ACEPoOX\\nJJf1lMqec+QCExd+VWwGSs5rG2ixxNyZ\\n=sJFr\\n-----END
         PGP PUBLIC KEY BLOCK-----\\n\", \n        \"type\": \"PGP\"\n      }, \n      \"last_updated\":
-        \"2018-10-22T22:41:41.599393Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
-        2, \n      \"remove_star_url\": \"/api/v1/sources/c7abe6eb-e9f6-4bea-9d82-740ffcf833b0/remove_star\",
-        \n      \"replies_url\": \"/api/v1/sources/c7abe6eb-e9f6-4bea-9d82-740ffcf833b0/replies\",
-        \n      \"submissions_url\": \"/api/v1/sources/c7abe6eb-e9f6-4bea-9d82-740ffcf833b0/submissions\",
-        \n      \"url\": \"/api/v1/sources/c7abe6eb-e9f6-4bea-9d82-740ffcf833b0\",
-        \n      \"uuid\": \"c7abe6eb-e9f6-4bea-9d82-740ffcf833b0\"\n    }, \n    {\n
-        \     \"add_star_url\": \"/api/v1/sources/9eaca32b-b1b7-40f2-b290-cdb3665df240/add_star\",
+        \"2019-03-19T18:18:37.336005Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
+        2, \n      \"remove_star_url\": \"/api/v1/sources/14738aa1-b256-4049-8f89-8c97e77d6b82/remove_star\",
+        \n      \"replies_url\": \"/api/v1/sources/14738aa1-b256-4049-8f89-8c97e77d6b82/replies\",
+        \n      \"submissions_url\": \"/api/v1/sources/14738aa1-b256-4049-8f89-8c97e77d6b82/submissions\",
+        \n      \"url\": \"/api/v1/sources/14738aa1-b256-4049-8f89-8c97e77d6b82\",
+        \n      \"uuid\": \"14738aa1-b256-4049-8f89-8c97e77d6b82\"\n    }, \n    {\n
+        \     \"add_star_url\": \"/api/v1/sources/6152a42d-fb5e-40d4-a94d-9eea7caf4f23/add_star\",
         \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
-        false, \n      \"journalist_designation\": \"crescent hammerhead\", \n      \"key\":
-        {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFvOUiYBEAC/LvvPFnDNksgboyivTh6zsd1/dgx4XJSbssapQ6jxvOBc7YXf\\nz+JY7fySyW+JGdinpF56p+wKZynMMFurBcePO3FFq4p1oMeKJNayWbcqWxNpZBrr\\njdczh+bv5NJ80i54eyNqbk5xB8kzyAbVEryRE3FlcxNfWL8Cukpmxkqhaa6FuTVx\\nWL4sOpfEXA9a3q6BKYkXdm3qu7WE0wWJvJtrcwHvDLOioT7ui7vTltT7fRCMPH35\\nfOxTwMBzDVHdOi4OtRAeRbAG0kC2seNturh+uNzluROqDeCX8vJfVrzWvHruCtjT\\nfWPU24qb683Hga1gXKrQqGsScxK6keJhdDGS4LIflClHs4IKItCGmfahjmbH+ba5\\nSOceMIhdT9+iPegs5TTUWB3euheg0PzDhAA/y3/AeqKKci29erQuIkDlJGSdNpvy\\nnMqzqh47Fxi2F2pavhIMuNuUEXf6CkBN7oq5Mpuvb1iFkwepThm2uEo7rxZ8hOPK\\nSqgocyOe7Zrd91hJPl6MJAkYDQZLZ9/Mfiv5ZV1myPo4nvcRLk+kNClh8KKDb+Ao\\nHcZJgbKUkYEdeTZ6sGStHHx92tU9R0wwlEXJMC50gO4K1BLuVvbeoyQ2zuQUWSyN\\n7G3RIWGGTwNHHxnauO9EUkFM3Fd7KnoyMJsgIy1zcSN6baP/c1OS+G9sswARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8NjRYMlVQNEpURFhMT1hWRko3VENORFpLR1VP\\nWEg2WUQ0R0RFSTNHVkJIUVAyVERFNVlYVlBIS1RKVldVUUtTRkpKVkhWQkxBWVlB\\nNlJaREs3M1NYWjdOM1AzMlRPT0FUTVhOS0VYUT0+iQI/BBMBCgApBQJbzlImAhsv\\nBQkB4J0aBwsJCAcDAgEGFQgCCQoLBBYCAwECHgECF4AACgkQFZngoIN/lTR3ng/+\\nMml7B9vPfCKaaehCilTqCj7s4o7Tt4wGjientC2ZcaEJCkJtSK/Z0wKUcUZD7q3f\\nyqFdEeHA5jawZZ/vIc+BwuqTI/66MmgeNja5EtSeAPxY70txoci3Tl/K8A5OHD/I\\nRDpOWmlTJGY6bRs/lwDu127kEcEjH+a9f8T7luOg7WnBsKQoLhQrcAm6ZfelPajJ\\nb9zwQDj2v/4cLqYfESqnQQ1QD7TLkHkUOvfEVhoLsf2NZvniZZIJ5f4A9EHzz17o\\n4UorreLmgpW2Z0loSczvoxhpoA48ffYKBakcdlISUDcxP3XnyJh0C5+6wCMVqz7/\\n34y2EeM0hbE8+b4ZPFW/Jb9HMPxVVaG20UhA2g5rK1xjju+NWXfs3O0Q2ZhbuAhX\\nR2p/qRvCkf0KvHUY1AGVIHkzlQ0pQlscxUzj21KWtWWfTBxJy1ocypjeVP3bxVKf\\nu+Du8JUiZjOkDqps8pNgpop8kuEEPgIpj/y0lNMpzBJizEl6M/mLYWZionuW2ccW\\npe+1zYa6dE9A2mGBOQv9EaNXz0CuOYV7MuIWvZqg0g1Joz9oWkjD6a/inldSZ4Fh\\nJbU8/kTP43UzkWcPhW3HXnasZu+3db9ACmqcqPNP7rO3uUmIfIe0fSDiWjfzhEwz\\nVNIAZ0ngTazQDSpz35NzZ+pTLCjBc6D1My0l4jZOSbU=\\n=cO9u\\n-----END
+        false, \n      \"journalist_designation\": \"unapproachable socialization\",
+        \n      \"key\": {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFGRfoABEADZLdX2qxqfxtJ/tbuloGq9v3cnVWvn2+Aw4HIloWpdOr90Mf2u\\n7vFYHIlxWmzq2ECRnqeSYC5+mC1FAd41EiWQIS6ouWVdE2IKQqoflmiTW0w1ozPd\\n1PHcCpSGtm36/J3YjPNezuowh7cObI67QXloug/3hK1ds2/ZSPguu83koCWZfqWu\\naScBmG9vRTKSiJ5fARE8y9CYTWYQH7grX24Fh+++mJk3gjsvuMpa3eXsN28EHYhZ\\n6Ce7BXgYqgQKhJxwg4HyFJE60hnQUalibg19kOcGkpVPWjZ5WMBv17Lt4mE7Qc2E\\nhHYaBeyrZRVrkBt0n+V0CRhPtPAiwVGYQQ+8OC+xCSfReiMjcRe6BlQR+zLfmpIy\\nkNw/LkkI03onMQZKpt+qdn0brTROo8GD4R9tp5yvOOuMrx0wxQTvNKL3ccnqRE6M\\ntsxHFEvt6CXckYqcYnCePToMmFdKjYlRwjgaLMwoRe34CYdu3DGGnIzLCWoAT84S\\nGBZfg2pRevzwGwrZlC3bJX50j6wzSBN+czIlIsQU4ph7xwFn0FSndLqpPyI/H0tA\\nwM0aYcFUqauazWb2UacoBmPpwlfCgptxjMbVCF0MgTwMQF5FWvOis5mV3tgGKkWa\\now6D1xmwIjQptoTCH1O6d81vejA/WOuPqzlBe8IQfeEUnmEy1WqE9OsoLwARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8WDNZWldTSllNSTJYWVRUSVNQQ1MzV0xCN0xM\\nS0NaWUxTNlhUV1g2QkdaQ01WSTZMTzdNWDc0NURaTkJWUlBGQ1A1VFVOWkQ3UVNQ\\nSklKUlBaUEtMVDI1V09BMjNZUDREM0xWN1RCUT0+iQI3BBMBCgAhBQJRkX6AAhsv\\nBQsJCAcCBhUICQoLAgQWAgMBAh4BAheAAAoJEJpbTCl+0Do/UFcQAKwmzEWYVRv+\\n4YFZMVt4/1sqjVRrAh3Hs1PHlWnQLUklKK9/RrtGXDlnK+qkhcx/Ros2C2CCfHyB\\nOM6/hinZnvKdEtfn04Zp4ETTJJTd1rPvswEmWwpI6d7q16Ei+ySbCzvFU9L9AW7M\\nd6F83bF6c97VeMONoCmS0YZDvWtje7ehRBwH1psCkqm7wrCEH80taZMsHbMuaVbk\\nNdzscM8cqu1QU90FgLTTd1KEwQJcKIsZzw3gC/uRqBO5Czao6zJCKkQHgFKJ5UG8\\n+20OD2ZcgteMRqL0R/F4wCU6YhWwpMDo4Wv65FfCEUdmPcldLJ/OQLrm5qPHtcYb\\nGQjrk1l6mo4suRbIE4i4mBajyE/WNKGLflGB4+MQjhvGDgS7suWDr9ddFxi9hr+d\\nHS48zN8hL9ARlSMhxbNINmJBEdsHxjPJvIMHHA6eO2mRdyQfHZTmfprLY+92XyXN\\nWixUpqAGI2MnhXohd7Wyz3si9Cf2oi+rmOunWki/BJ2o6QAuG1soFkYOebvGzY+k\\nLtCL1nLt7EydlcWbBENbTkMJH0drdqO22D8U2vEzbLnVoZ84XBeWqypEcBxXXqqP\\n7VwLAcXbjMj9P35/mJUs7N8cngUPb9tTHeBOybqsay7NMpv97wYdgEFYkFaKXPeB\\n/usPcLR/AMOZLM9VSJbuf00sY7S5/L9p\\n=KNNT\\n-----END
         PGP PUBLIC KEY BLOCK-----\\n\", \n        \"type\": \"PGP\"\n      }, \n      \"last_updated\":
-        \"2018-10-22T22:41:44.151239Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
-        2, \n      \"remove_star_url\": \"/api/v1/sources/9eaca32b-b1b7-40f2-b290-cdb3665df240/remove_star\",
-        \n      \"replies_url\": \"/api/v1/sources/9eaca32b-b1b7-40f2-b290-cdb3665df240/replies\",
-        \n      \"submissions_url\": \"/api/v1/sources/9eaca32b-b1b7-40f2-b290-cdb3665df240/submissions\",
-        \n      \"url\": \"/api/v1/sources/9eaca32b-b1b7-40f2-b290-cdb3665df240\",
-        \n      \"uuid\": \"9eaca32b-b1b7-40f2-b290-cdb3665df240\"\n    }\n  ]\n}\n"}
+        \"2019-03-19T18:18:39.659948Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
+        2, \n      \"remove_star_url\": \"/api/v1/sources/6152a42d-fb5e-40d4-a94d-9eea7caf4f23/remove_star\",
+        \n      \"replies_url\": \"/api/v1/sources/6152a42d-fb5e-40d4-a94d-9eea7caf4f23/replies\",
+        \n      \"submissions_url\": \"/api/v1/sources/6152a42d-fb5e-40d4-a94d-9eea7caf4f23/submissions\",
+        \n      \"url\": \"/api/v1/sources/6152a42d-fb5e-40d4-a94d-9eea7caf4f23\",
+        \n      \"uuid\": \"6152a42d-fb5e-40d4-a94d-9eea7caf4f23\"\n    }\n  ]\n}\n"}
     headers:
-      Content-Length: ['5245']
+      Content-Length: ['5228']
       Content-Type: [application/json]
-      Date: ['Mon, 22 Oct 2018 22:41:58 GMT']
-      Server: [Werkzeug/0.14.1 Python/2.7.6]
-      Set-Cookie: [js=eyJleHBpcmVzIjp7IiBkIjoiVHVlLCAyMyBPY3QgMjAxOCAwMDo0MTo1OCBHTVQifX0.Dq_jtg.QIkHRFQrSFIxNmv3awdJjiXXT18;
-          HttpOnly; Path=/]
-      Vary: [Cookie]
+      Date: ['Tue, 19 Mar 2019 18:18:53 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
     status: {code: 200, message: OK}
 version: 1

--- a/data/test-get-submission.yml
+++ b/data/test-get-submission.yml
@@ -9,7 +9,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources
+    uri: http://127.0.0.1:8081/api/v1/sources
   response:
     body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/812948a6-796f-4d2b-8112-5dd25e09130e/add_star\",
         \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
@@ -52,7 +52,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources/812948a6-796f-4d2b-8112-5dd25e09130e/submissions
+    uri: http://127.0.0.1:8081/api/v1/sources/812948a6-796f-4d2b-8112-5dd25e09130e/submissions
   response:
     body: {string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/812948a6-796f-4d2b-8112-5dd25e09130e/submissions/fd20e9ce-663b-48c8-8cc2-bdaff00f95da/download\",
         \n      \"filename\": \"1-liked_crockery-msg.gpg\", \n      \"is_read\": false,
@@ -83,7 +83,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources/812948a6-796f-4d2b-8112-5dd25e09130e/submissions/fd20e9ce-663b-48c8-8cc2-bdaff00f95da
+    uri: http://127.0.0.1:8081/api/v1/sources/812948a6-796f-4d2b-8112-5dd25e09130e/submissions/fd20e9ce-663b-48c8-8cc2-bdaff00f95da
   response:
     body: {string: "{\n  \"download_url\": \"/api/v1/sources/812948a6-796f-4d2b-8112-5dd25e09130e/submissions/fd20e9ce-663b-48c8-8cc2-bdaff00f95da/download\",
         \n  \"filename\": \"1-liked_crockery-msg.gpg\", \n  \"is_read\": false, \n

--- a/data/test-get-submission.yml
+++ b/data/test-get-submission.yml
@@ -4,99 +4,117 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU0MDI3NjkxOCwiaWF0IjoxNTQwMjQ4MTE4fQ.eyJpZCI6MX0.fygpQy3CxB1ulUWLFz2UdrtcBKHz-fk5gyRxbcSY720]
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1MzA1MDU5MCwiaWF0IjoxNTUzMDIxNzkwfQ.eyJpZCI6MX0.16UNxpkI4yOEI6Jqsz3hrmjhgqSiw61xAENb654nRX0]
       Connection: [keep-alive]
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://127.0.0.1:8081/api/v1/sources
+    uri: http://127.0.0.1:8081/api/v1/submissions
   response:
-    body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/812948a6-796f-4d2b-8112-5dd25e09130e/add_star\",
-        \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
-        false, \n      \"journalist_designation\": \"liked crockery\", \n      \"key\":
-        {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFvOUtcBEADdTdl0L1u8ODCNOBvDG/Fts9EFsZ+ptsLnOsXinvwgz//n1rSs\\nlAK6lmdC4sy6xjprtK9/9wcE2YQOvn8jF42Ngwbb1bII2TluX3i+4vnihBRR6DRE\\nEyEhHmdj6QV9++3byT1NDSXCi4j5RqYzagBKOvAOxyJwdjkUqCHLPxLaZD4B9Lyu\\ns/4pqVb2DlJaqdDp0N4+/AMZwMzSCB3a2ehOpU91vSZ+PNSEHwZTbveoWoH1R1AW\\nmgFkoIAOMrapTat6JWgGCCmtsIcxSA+drtk0ejv/5FeFqn6qnF9CyI74kLOvpWGs\\nuccHULc/1TrFNId/DmsWXIT9hWEE5BJXamQE230AvUuOjsiPQSuDFvD+vOcnhcVB\\nET5QZBKiBDE2WbcoNmq5i1LWw48Q9tZgMuvCtjzXf4QvaQsb9JHsEPPQeRAmBqWm\\nnlYUNfKpPuIB8q9Mg5DTX6nJ2jSr+PsLFQOz4RE9cZS/s516K9wRf92DZiPMxLEv\\ney4SHXyjK60OdclFU8MVg8HySabQV0ffTSSn5S4R4N0Qy0NndrkW5ll1tCKSeB7O\\npzwwaJuLT3VC+rLkEeqajqWQa5SIgwUXmBl3bQkbpbO9hgEBvzdczsbYvAh6WgNY\\n9l3dlqL3HojEvlvjrB38En6qUgmWyJgiLAz6cf91WhmkIlfvdD9kfPJ2lwARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8SkNSQ05OTDVLUEZCQlZRQ0hNN0ZENFBQWkNS\\nRklUN040WVBOVjdaNUVMQlJLS1lGUFVYQ0NQRFFORFhaUFlZRlJIWjNLUkxKSk9H\\nUkE1R1dEWTdWQ0NPNzRMQ0tBNEtPWVFaVE9ZUT0+iQI/BBMBCgApBQJbzlLXAhsv\\nBQkB4JxpBwsJCAcDAgEGFQgCCQoLBBYCAwECHgECF4AACgkQelrz0V6nPsqkcRAA\\nhNUJMDpFe76xHtLgcZwzxvbFmop40VQPJCJXWl5JsE0rEvrXa64qrDzgyj7a0F8v\\n9pk8M9OvNXXFMQEsqtYqbJGdfA3H53uLO4doj4OrQmappqqBSlof3xqRHJrbWVGk\\n20/ZKUrJvbvFlU9OD0lmWbXS60W9UfPRhCe7p++rKftpF/JZCOicD9DvtqyJalVW\\n7UDpektYL5bovLqcYCofNDoBpARPEeN4eXI6ltWj+92HMwvvYOwkLQO9dz+oCtux\\nBcBDiw15mYrvLqESGBUpDxN9B/iR5VKnq/kyUVNNbXdSZadaVtpwJD2DOXnffGd1\\nnVJ/0ok3DZFcb62IjCJTeQMT9E/fGdfk6ncQ3ocnvWf7zih4GqxskHHSVGpGxiXf\\n2tnxY6VOtU/NuOL7wsvWtAre+c3JgvulklbuDxgPLJpmYB9Uu/5C+l8ToTsfm6w8\\nNHMIILqNd1iY55yLDApky68nuKT856eZ4t1j8eh6wZWResWthIN9eox+nLDX39r3\\neeIFQC1NloXsyxWB2W1LYco1wTaVvr1U47omGNNHG7m+X52m5xjros2vPGJswNdo\\nirlrXBBMcSIY/XuPoYij69EpeHcL/7OcH0XKmgHNeE+agGuct3AXSnXEZ2/GrmBH\\nxyaSMA/Z7nRmKtj5lJyHqSoGcydnQ/UlXLPz47HbXbk=\\n=bwVa\\n-----END
-        PGP PUBLIC KEY BLOCK-----\\n\", \n        \"type\": \"PGP\"\n      }, \n      \"last_updated\":
-        \"2018-10-22T22:44:39.563172Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
-        2, \n      \"remove_star_url\": \"/api/v1/sources/812948a6-796f-4d2b-8112-5dd25e09130e/remove_star\",
-        \n      \"replies_url\": \"/api/v1/sources/812948a6-796f-4d2b-8112-5dd25e09130e/replies\",
-        \n      \"submissions_url\": \"/api/v1/sources/812948a6-796f-4d2b-8112-5dd25e09130e/submissions\",
-        \n      \"url\": \"/api/v1/sources/812948a6-796f-4d2b-8112-5dd25e09130e\",
-        \n      \"uuid\": \"812948a6-796f-4d2b-8112-5dd25e09130e\"\n    }, \n    {\n
-        \     \"add_star_url\": \"/api/v1/sources/0fe2a494-cda9-4201-9fb5-b4c672568eb1/add_star\",
-        \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
-        false, \n      \"journalist_designation\": \"adherent competition\", \n      \"key\":
-        {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFvOUtgBEAC+wZoYqH2/S0O7kZd46DwKEuHbiL1E5FRjZYMEn1ZxdHJAMkpU\\nOl8agjDMwqDTSn3XV5xP0CICChBXytd9VWByyL4BTcNHtg6j9d6XjDe6q/IHP92b\\niBd+IdKAQnzZ+IFhT54mNJzX3rRVMt23RiMxjAhfK9d3c584Fyd7LDbj6DINCg+q\\n7SSYso9Lxhl7F7n30wesqgTyOnFkgGawjiyOzWZeeeHlKmm3Zqhkni22GoP/zGT+\\nQHPATDxHhShAdB9i3+yeT7m3TCwvJ9ReK+GPcBBHVYyxxhrF8XIbAOHODiCU1v2L\\nYSa9nhNtWo+xSYt6VYKzXPnXKJDdrGPROmTQWgpb+5n1WawJx4AMn7ZeNQWKoS3d\\nyx6DmFMyi2xbvtLrXHAMrL2XlhPh/lt5T0KvdqEaBLjau6OYwvax9BkmFtnZJkrW\\nagWoyxEBXOxWfQYYQYLhnG4Sx33rNV/Lv/+Zc06wFWyNFfM/2i1Sw6p0X36Ykjlo\\nRsfib/AM9Y4CNtlz5Vmy3A6635xETp0Bo0244sF7hjxcSRgW3rpNS42ELYdvmKxn\\nW4PvvIMMZJ3Ev0pWWtnUDGYwykm+X7P2/PIiIO8t6DVsqVxX4Wk6V4tnAdE3k0P+\\ngi+WZLhe0U1YQIJPAcOBnjdToghmEZKHjpNIGANRZ42YecfOJxhCWw/sRwARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8TElaRFhITlVEUFFNVUc1SzdBVVVGSjI3TTc0\\nM0k2UVpRVExUVlY2MzNNQ0NFVzNPN0VMSlQzM1hVM0tZWlZZTkhYSElJUlo0N0RN\\nUUZQWFlXR0gzSE5RRzcyR0w3U1FDQUU3Q0VYQT0+iQI/BBMBCgApBQJbzlLYAhsv\\nBQkB4JxoBwsJCAcDAgEGFQgCCQoLBBYCAwECHgECF4AACgkQsLqvJ5AlM6LfhA/+\\nOj2WZO0++uZumsjizWW+F0gytLxT7JhIcs2u+BGdFCNt0FM1Nkwi6d4+iTTKApPf\\nqFfbXKkUwMy5hnRCZYLp0rTnuJ/lfbCOziZ0oSsQtoPUC7g80nGpRt2LZgGTnLh3\\nT/m9Z80lDHskhUURgfYATQPOdiH02Ml2GJhzAVKd8xfwOZ0lwL/ZwR8OZffMKUs6\\n2MD+8rxzebNF0/Oau4l8g8tLc8OnYYC+EB5mpWP1BzOXK8B6EaKft6jo8eNSHAVl\\nk8BPAdQeY5vOxI6c7eBke7bVhqkU66pV6INfrhQSTms9SzRhCFkZt3PGpqOGAfxA\\nxNQfXNNYo3SOcvZ4l+CAuZ0XKk9fxUB5yvN9ng8WOiuA5et3/FsqF5owYiX0qOWX\\niy8obcCSvK1ye7mweSaIlXxpH5eWMGNvsa6LcF5+jQyc/nsQkauf0kdRxhRrZ/k1\\n2fCUA4m4rw7jFFQDM4vetXAtP0JOI+grvK7PYkAzUZqoFqeUk2tqG0tA3oEFef98\\nHKPMZS7buQyuMFtaylA8qmbLQ4Iu+xrKoakOXsj9+hQW7AjTxNv2kTbIea+TIWC7\\neglLznBmrNU9bvYSE9mH7pIsKESnRatPyOxkND7YKXJGbSbgZvL4RtQFkiVPvE+8\\nlNdFeUoU0B1znKWRUltex6qwo0ulxT93P1XUFoQjbbI=\\n=SYrM\\n-----END
-        PGP PUBLIC KEY BLOCK-----\\n\", \n        \"type\": \"PGP\"\n      }, \n      \"last_updated\":
-        \"2018-10-22T22:44:41.526914Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
-        2, \n      \"remove_star_url\": \"/api/v1/sources/0fe2a494-cda9-4201-9fb5-b4c672568eb1/remove_star\",
-        \n      \"replies_url\": \"/api/v1/sources/0fe2a494-cda9-4201-9fb5-b4c672568eb1/replies\",
-        \n      \"submissions_url\": \"/api/v1/sources/0fe2a494-cda9-4201-9fb5-b4c672568eb1/submissions\",
-        \n      \"url\": \"/api/v1/sources/0fe2a494-cda9-4201-9fb5-b4c672568eb1\",
-        \n      \"uuid\": \"0fe2a494-cda9-4201-9fb5-b4c672568eb1\"\n    }\n  ]\n}\n"}
+    body: {string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/92ce92a4-81aa-4a68-8d9f-4636e0d00114/submissions/52f8cd06-9930-4df3-91be-d85ce7ad150a/download\",
+        \n      \"filename\": \"1-saurian_parley-msg.gpg\", \n      \"is_read\": false,
+        \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/92ce92a4-81aa-4a68-8d9f-4636e0d00114\",
+        \n      \"submission_url\": \"/api/v1/sources/92ce92a4-81aa-4a68-8d9f-4636e0d00114/submissions/52f8cd06-9930-4df3-91be-d85ce7ad150a\",
+        \n      \"uuid\": \"52f8cd06-9930-4df3-91be-d85ce7ad150a\"\n    }, \n    {\n
+        \     \"download_url\": \"/api/v1/sources/92ce92a4-81aa-4a68-8d9f-4636e0d00114/submissions/16c4b949-ce72-4630-afe1-3edc6fb9a164/download\",
+        \n      \"filename\": \"2-saurian_parley-msg.gpg\", \n      \"is_read\": false,
+        \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/92ce92a4-81aa-4a68-8d9f-4636e0d00114\",
+        \n      \"submission_url\": \"/api/v1/sources/92ce92a4-81aa-4a68-8d9f-4636e0d00114/submissions/16c4b949-ce72-4630-afe1-3edc6fb9a164\",
+        \n      \"uuid\": \"16c4b949-ce72-4630-afe1-3edc6fb9a164\"\n    }, \n    {\n
+        \     \"download_url\": \"/api/v1/sources/64d64bd4-3b84-4b13-b80b-bfe550e92600/submissions/59d06a2b-a175-4d46-94c8-1c4d928c115b/download\",
+        \n      \"filename\": \"1-archival_advancement-msg.gpg\", \n      \"is_read\":
+        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/64d64bd4-3b84-4b13-b80b-bfe550e92600\",
+        \n      \"submission_url\": \"/api/v1/sources/64d64bd4-3b84-4b13-b80b-bfe550e92600/submissions/59d06a2b-a175-4d46-94c8-1c4d928c115b\",
+        \n      \"uuid\": \"59d06a2b-a175-4d46-94c8-1c4d928c115b\"\n    }, \n    {\n
+        \     \"download_url\": \"/api/v1/sources/64d64bd4-3b84-4b13-b80b-bfe550e92600/submissions/1cf8dd19-a9bc-487f-9505-355daea34e85/download\",
+        \n      \"filename\": \"2-archival_advancement-msg.gpg\", \n      \"is_read\":
+        false, \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/64d64bd4-3b84-4b13-b80b-bfe550e92600\",
+        \n      \"submission_url\": \"/api/v1/sources/64d64bd4-3b84-4b13-b80b-bfe550e92600/submissions/1cf8dd19-a9bc-487f-9505-355daea34e85\",
+        \n      \"uuid\": \"1cf8dd19-a9bc-487f-9505-355daea34e85\"\n    }\n  ]\n}\n"}
     headers:
-      Content-Length: ['5237']
+      Content-Length: ['2049']
       Content-Type: [application/json]
-      Date: ['Mon, 22 Oct 2018 22:44:45 GMT']
-      Server: [Werkzeug/0.14.1 Python/2.7.6]
-      Set-Cookie: [js=eyJleHBpcmVzIjp7IiBkIjoiVHVlLCAyMyBPY3QgMjAxOCAwMDo0NDo0NSBHTVQifX0.Dq_kXQ.xvFvIVdu41OSbLqQ8INC6cxUcyk;
-          HttpOnly; Path=/]
-      Vary: [Cookie]
+      Date: ['Tue, 19 Mar 2019 18:56:30 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU0MDI3NjkxOCwiaWF0IjoxNTQwMjQ4MTE4fQ.eyJpZCI6MX0.fygpQy3CxB1ulUWLFz2UdrtcBKHz-fk5gyRxbcSY720]
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1MzA1MDU5MCwiaWF0IjoxNTUzMDIxNzkwfQ.eyJpZCI6MX0.16UNxpkI4yOEI6Jqsz3hrmjhgqSiw61xAENb654nRX0]
       Connection: [keep-alive]
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://127.0.0.1:8081/api/v1/sources/812948a6-796f-4d2b-8112-5dd25e09130e/submissions
+    uri: http://127.0.0.1:8081/api/v1/sources/92ce92a4-81aa-4a68-8d9f-4636e0d00114
   response:
-    body: {string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/812948a6-796f-4d2b-8112-5dd25e09130e/submissions/fd20e9ce-663b-48c8-8cc2-bdaff00f95da/download\",
-        \n      \"filename\": \"1-liked_crockery-msg.gpg\", \n      \"is_read\": false,
-        \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/812948a6-796f-4d2b-8112-5dd25e09130e\",
-        \n      \"submission_url\": \"/api/v1/sources/812948a6-796f-4d2b-8112-5dd25e09130e/submissions/fd20e9ce-663b-48c8-8cc2-bdaff00f95da\",
-        \n      \"uuid\": \"fd20e9ce-663b-48c8-8cc2-bdaff00f95da\"\n    }, \n    {\n
-        \     \"download_url\": \"/api/v1/sources/812948a6-796f-4d2b-8112-5dd25e09130e/submissions/f0dcf445-271f-4b7d-9b77-f1701c81b11b/download\",
-        \n      \"filename\": \"2-liked_crockery-msg.gpg\", \n      \"is_read\": false,
-        \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/812948a6-796f-4d2b-8112-5dd25e09130e\",
-        \n      \"submission_url\": \"/api/v1/sources/812948a6-796f-4d2b-8112-5dd25e09130e/submissions/f0dcf445-271f-4b7d-9b77-f1701c81b11b\",
-        \n      \"uuid\": \"f0dcf445-271f-4b7d-9b77-f1701c81b11b\"\n    }\n  ]\n}\n"}
+    body: {string: "{\n  \"add_star_url\": \"/api/v1/sources/92ce92a4-81aa-4a68-8d9f-4636e0d00114/add_star\",
+        \n  \"interaction_count\": 4, \n  \"is_flagged\": false, \n  \"is_starred\":
+        false, \n  \"journalist_designation\": \"saurian parley\", \n  \"key\": {\n
+        \   \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFGRfoABEACybFLV8+B4SkE/Ier8Zw/FTUa0QHpRAXzQfZYJQ7AIe9nmvwmL\\nha8yvLH/2TVu9h9vqMqVDdSOGq7AyqzZJUSvO9g3YJD+reMXzrHCQynlBp1ljFyZ\\nDcfH2WXG0GougWuxcC5FRixUb55t3Oi3jUecQyBa8sTp5GvuFZ5TTpzmXBJn8oa8\\nwXJlZFkg99fkSvhGCjG7rR80PNB2NaAKFI2yXxCNsrpMktzbKF/683LJxiPWRmqS\\nSeJHKynwyE8TXdUTkdvp18NR2VV+rXyAoQJZBcer1e96SSyNrnNuXnznOuHyc0Tz\\nxLEgLECeu7bt8tKRPzn+2e+EqDRceeK67p+annHMDSsIegVeQllR9cDD7MoRduOM\\nT9hWUldcajjpDA0exap+p8vXzxhbdRxZREgqCl1eMxmvT5ggv3xErcw3xJqMpYl2\\npx2ZVZnlwbgXS757qhhS8CPukBIQVsh/jeA9UHyI1IwsKExzy7Yyam6/gimkDlE+\\ntgS6z5axEGc3nI1MPP0IUm4ifHKixEGClGAE3TZvLex+tcXDHmzB2LKUaHUGEIZV\\nNGnH6o2kxqxwCgMCTmA1HlGLUqCLOq+8XQ8QZXRmvkUL6C8C0JJB9x+7yBw996g0\\nSOaibc1tfGJz+0tus7lklt8cwVpPwWc9Rj1J0KRgPoSTeriToKChYmf0iwARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8SFlTNDY3SFdOQjdRUkhHWTROS1g1Mk4ySkE2\\nN1hWV0JNR0tZU0tDRTZVTURKUUhQT0ZBTE1MUExORjM0SUNWSFpEVVAzV0MzRTVa\\nNlNOVk5TRVpRNllYWTRKNUpIVU42UVdYQTdOUT0+iQI3BBMBCgAhBQJRkX6AAhsv\\nBQsJCAcCBhUICQoLAgQWAgMBAh4BAheAAAoJEDGBnpwhwH88AlYQAJWQm6EE1NCr\\ndOM1grKGsPZx7ELb/6+4lQRlO2mEQfy9ngOMmJygQXdULGfY53f1QohBsEV2dvCQ\\niVlVNA42CF7TcEQW9qXR8hZbMF/WWxsGHjm/Andvb5NA4NYdd4WoVQs38ws/VV0z\\nggGsM6o99/9HamhQjXUZNcXhj1INf7jG7I/mFECV/ZUWs5Q6ChfONnw65Tg6CBoL\\nmieTK8snhepq0pmBABtsiN5MPn3XfcWBZXB5Lm4429IBHVRBNTt4L/g/3n+iQ9j/\\nPE/40GRBSOvoTlfxrnskA3TYaSodxz4yX1qlYTGPhL/tIRzJHTRZYF60+DKsgitH\\nI5wanH5KA11ZjuhfL025Uvi2uBBEwWRQaY67Hj8qg8ptxfw9CDznssnh2Fx6cOX8\\n+AlELuJ0avubvKc9m7hpWfrrlWSBltVDs9ZDOdA9ZGg2Jdo8MIky/nYevVOUZQ7X\\nJ/02VJx0b6gSTtMxsXoYi7YoU61qmV1UYJFyebhSC1NRtGyiHhdRT/oizKFNmAUE\\n1lokWTxMqV8Nyc+DqdCfMLKYXrqJodJdBSPFbVOI4q7M3Pvh3m2mzp76uXCl1pRg\\nGyRqYDRTlpmRz2AGm7xSpVFNnRCqUwCXEpQTudwkPv+eEx4nseNDNHYdSd36Teva\\nKBVvCg5ykdCYpaeSSVRWwXVdxJK74MmM\\n=7Ki5\\n-----END
+        PGP PUBLIC KEY BLOCK-----\\n\", \n    \"type\": \"PGP\"\n  }, \n  \"last_updated\":
+        \"2019-03-19T18:53:26.366059Z\", \n  \"number_of_documents\": 0, \n  \"number_of_messages\":
+        2, \n  \"remove_star_url\": \"/api/v1/sources/92ce92a4-81aa-4a68-8d9f-4636e0d00114/remove_star\",
+        \n  \"replies_url\": \"/api/v1/sources/92ce92a4-81aa-4a68-8d9f-4636e0d00114/replies\",
+        \n  \"submissions_url\": \"/api/v1/sources/92ce92a4-81aa-4a68-8d9f-4636e0d00114/submissions\",
+        \n  \"url\": \"/api/v1/sources/92ce92a4-81aa-4a68-8d9f-4636e0d00114\", \n
+        \ \"uuid\": \"92ce92a4-81aa-4a68-8d9f-4636e0d00114\"\n}\n"}
+    headers:
+      Content-Length: ['2515']
+      Content-Type: [application/json]
+      Date: ['Tue, 19 Mar 2019 18:56:30 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1MzA1MDU5MCwiaWF0IjoxNTUzMDIxNzkwfQ.eyJpZCI6MX0.16UNxpkI4yOEI6Jqsz3hrmjhgqSiw61xAENb654nRX0]
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: http://127.0.0.1:8081/api/v1/sources/92ce92a4-81aa-4a68-8d9f-4636e0d00114/submissions
+  response:
+    body: {string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/92ce92a4-81aa-4a68-8d9f-4636e0d00114/submissions/52f8cd06-9930-4df3-91be-d85ce7ad150a/download\",
+        \n      \"filename\": \"1-saurian_parley-msg.gpg\", \n      \"is_read\": false,
+        \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/92ce92a4-81aa-4a68-8d9f-4636e0d00114\",
+        \n      \"submission_url\": \"/api/v1/sources/92ce92a4-81aa-4a68-8d9f-4636e0d00114/submissions/52f8cd06-9930-4df3-91be-d85ce7ad150a\",
+        \n      \"uuid\": \"52f8cd06-9930-4df3-91be-d85ce7ad150a\"\n    }, \n    {\n
+        \     \"download_url\": \"/api/v1/sources/92ce92a4-81aa-4a68-8d9f-4636e0d00114/submissions/16c4b949-ce72-4630-afe1-3edc6fb9a164/download\",
+        \n      \"filename\": \"2-saurian_parley-msg.gpg\", \n      \"is_read\": false,
+        \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/92ce92a4-81aa-4a68-8d9f-4636e0d00114\",
+        \n      \"submission_url\": \"/api/v1/sources/92ce92a4-81aa-4a68-8d9f-4636e0d00114/submissions/16c4b949-ce72-4630-afe1-3edc6fb9a164\",
+        \n      \"uuid\": \"16c4b949-ce72-4630-afe1-3edc6fb9a164\"\n    }\n  ]\n}\n"}
     headers:
       Content-Length: ['1031']
       Content-Type: [application/json]
-      Date: ['Mon, 22 Oct 2018 22:44:45 GMT']
-      Server: [Werkzeug/0.14.1 Python/2.7.6]
-      Set-Cookie: [js=eyJleHBpcmVzIjp7IiBkIjoiVHVlLCAyMyBPY3QgMjAxOCAwMDo0NDo0NSBHTVQifX0.Dq_kXQ.xvFvIVdu41OSbLqQ8INC6cxUcyk;
-          HttpOnly; Path=/]
-      Vary: [Cookie]
+      Date: ['Tue, 19 Mar 2019 18:56:30 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU0MDI3NjkxOCwiaWF0IjoxNTQwMjQ4MTE4fQ.eyJpZCI6MX0.fygpQy3CxB1ulUWLFz2UdrtcBKHz-fk5gyRxbcSY720]
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1MzA1MDU5MCwiaWF0IjoxNTUzMDIxNzkwfQ.eyJpZCI6MX0.16UNxpkI4yOEI6Jqsz3hrmjhgqSiw61xAENb654nRX0]
       Connection: [keep-alive]
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://127.0.0.1:8081/api/v1/sources/812948a6-796f-4d2b-8112-5dd25e09130e/submissions/fd20e9ce-663b-48c8-8cc2-bdaff00f95da
+    uri: http://127.0.0.1:8081/api/v1/sources/92ce92a4-81aa-4a68-8d9f-4636e0d00114/submissions/52f8cd06-9930-4df3-91be-d85ce7ad150a
   response:
-    body: {string: "{\n  \"download_url\": \"/api/v1/sources/812948a6-796f-4d2b-8112-5dd25e09130e/submissions/fd20e9ce-663b-48c8-8cc2-bdaff00f95da/download\",
-        \n  \"filename\": \"1-liked_crockery-msg.gpg\", \n  \"is_read\": false, \n
-        \ \"size\": 604, \n  \"source_url\": \"/api/v1/sources/812948a6-796f-4d2b-8112-5dd25e09130e\",
-        \n  \"submission_url\": \"/api/v1/sources/812948a6-796f-4d2b-8112-5dd25e09130e/submissions/fd20e9ce-663b-48c8-8cc2-bdaff00f95da\",
-        \n  \"uuid\": \"fd20e9ce-663b-48c8-8cc2-bdaff00f95da\"\n}\n"}
+    body: {string: "{\n  \"download_url\": \"/api/v1/sources/92ce92a4-81aa-4a68-8d9f-4636e0d00114/submissions/52f8cd06-9930-4df3-91be-d85ce7ad150a/download\",
+        \n  \"filename\": \"1-saurian_parley-msg.gpg\", \n  \"is_read\": false, \n
+        \ \"size\": 604, \n  \"source_url\": \"/api/v1/sources/92ce92a4-81aa-4a68-8d9f-4636e0d00114\",
+        \n  \"submission_url\": \"/api/v1/sources/92ce92a4-81aa-4a68-8d9f-4636e0d00114/submissions/52f8cd06-9930-4df3-91be-d85ce7ad150a\",
+        \n  \"uuid\": \"52f8cd06-9930-4df3-91be-d85ce7ad150a\"\n}\n"}
     headers:
       Content-Length: ['465']
       Content-Type: [application/json]
-      Date: ['Mon, 22 Oct 2018 22:44:45 GMT']
-      Server: [Werkzeug/0.14.1 Python/2.7.6]
-      Set-Cookie: [js=eyJleHBpcmVzIjp7IiBkIjoiVHVlLCAyMyBPY3QgMjAxOCAwMDo0NDo0NSBHTVQifX0.Dq_kXQ.xvFvIVdu41OSbLqQ8INC6cxUcyk;
-          HttpOnly; Path=/]
-      Vary: [Cookie]
+      Date: ['Tue, 19 Mar 2019 18:56:30 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
     status: {code: 200, message: OK}
 version: 1

--- a/data/test-get-submissions.yml
+++ b/data/test-get-submissions.yml
@@ -4,73 +4,67 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU0MDI3NjkxOCwiaWF0IjoxNTQwMjQ4MTE4fQ.eyJpZCI6MX0.fygpQy3CxB1ulUWLFz2UdrtcBKHz-fk5gyRxbcSY720]
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1MzA0NzYxMywiaWF0IjoxNTUzMDE4ODEzfQ.eyJpZCI6MX0.S1gNx3iwOmQgjjY7Pqhmkpbk3JCszng0eu31LbMOQhM]
       Connection: [keep-alive]
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
     uri: http://127.0.0.1:8081/api/v1/sources
   response:
-    body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/26fe81f9-4d35-4999-9fd6-70963e9fd664/add_star\",
+    body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/add_star\",
         \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
-        false, \n      \"journalist_designation\": \"edifying skirl\", \n      \"key\":
-        {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFvOUr0BEACvcCyZhtHIISBjknSpJdjfKdqg3BHpVCgMEwCU0X1OgMgeRhCv\\np1SEDuIMYA4j35imZmohVFZMkDJTGzwaSGHpcUeOfzTtmSWBSNdpSuMwg4+xteEL\\nBY6o3gfu+L92Q3b9T2wAhGsHBJ+YODW3ShkWSF7hms1fdCMtm0z2C2GraoQGL91c\\nhr1KAQ/AZ5Sp/2ZV7T6AODT0HxETGM8FwWs2PNFtjAiKKC3wnAZswGPcEnfFj+ds\\nbRBZ1ebdEtYGAJ9q08suvoKLdNkBN0qsv5ws72C4tzSAeYTrXLvGdnABh/MjUxI4\\n6Hp0yYjTGbWHfvXOKtCDpvW48ZJTVumwiaeNWCh45UAnpFUa5LnESD7aUgemWUXh\\nkV2ot0Z8hGdvyW+NqrQkj7LrrHSKGGsbDOtdeIZZvyLoSzGYzxjqFOw2fqFLxJlf\\nOmmd1fOWh3MR2f99Nuh83szU13on4PttbSYZBEZbexMV0InHBxfMT+MvG32LcE1B\\n2WTev1yRDaqIUFFXNppdjv5xhncnO7DPduxw2NTd8oJQdvC2k5PqlJuyRci5q+Ke\\n2qyaSe0e6mWq3LCSq/CDWWN6LSvmp4Wn7wGwe+ueT8H0d4bnyQARkpmzNimZVBNX\\nks5cuZNY3kYxOS77Bk8tw913LJIoIzFRM2YuCmPRkJNJJ3WO3pAWpeQigwARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8RURPSDNKNjcyVFpKNVlCN1VYVElLRDNKUFRG\\nSUJHNUgzSkdLSEsyM1o2SEJHTTVITFpPSzJIUldVMlAzTlBITVBJVEQ3Szc0SUhH\\nNkRSUzNIVktTTUVONVAyQ0UzRVRWT1c3Rko3UT0+iQI/BBMBCgApBQJbzlK9Ahsv\\nBQkB4JyDBwsJCAcDAgEGFQgCCQoLBBYCAwECHgECF4AACgkQZAGdNw3GjJ0k8BAA\\nrCtl1OLHdjkYccJjuxmVXqYHLWANnkOgYdbT4sxx8NxnQwIGYnEkHs9NrPg9lstX\\n/FaVyfdq0dSDVT9GsJlpd6puDYBq+pQFCv1IT5IF7ZVhsA3XjKardkd4imzgZ1T0\\nzMPbCBOjrkBVBSKqadYUgGRemQagJs6xvmwkpRFf4iUqp/KuJQ7Fv3+jeHJSi+TS\\n5uRjg01rGuNT/6kGBrc1tD6aAKNhZsi96r0vlidvqMQ8GLUidyY+wDSB8UeqSV1+\\ntXiMlGSe9jvUrMPSORsqDqw+noBt3Z/Df7AkreIpr0qaWtSYJmxx0pRtJ8rYxozY\\npqzpxnspZC7bd+w4PnjZ+4Abh1EgrAMbbKIT2FeED/4ODxFgUQ+/6hQC4ITyaukb\\nJygNpdLIQleCezNWMpYqW5lIQwLaSf+/F8ehHwd/KcceozcHXzexojyGZ71BPGfv\\nDECEB7q3m758sy1F1OEejHCNb7VtXdhANQftYMwtOIvWpaQDJoCuqisHVhwTvZmM\\n0/dks45ha6k5TmqST8FW3bye98FVO5upFaFH9pr0pBPfRbNztpkjfU+u071gPDuQ\\ntV1TpRaLYnz8mc0sFEzEFtz3fVeDpgEAPgBdgd6vGYr7Q9L4FjRPMwzYgxd+71zz\\ndsgG2Ilor0elEnh4eofJ3GvQVeDpxEXRQByOG07q6c8=\\n=Si7y\\n-----END
+        false, \n      \"journalist_designation\": \"seamed betel\", \n      \"key\":
+        {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFGRfoABEADb9T/kz6wfGMdHgRyl0VqXmolVe2ll6m2ULXQMJ0F75OmgEMqX\\nQS7JF/GoyPUWfAr3KW5t1f909w29GKfOHcel48pTXwIjpBeYXkwgV/wQQ7l8jj1g\\nII/jv0EP5a8/DiP5tRjQ8/mO0wSdzZU9nWEdohvkHwvTuxjpUtiN8/qqo8cQU1uf\\n78Psnsb3SEP5J5debt/TfEaTg7YdEnTUo50WMVksp6tVyl4vsE7Pi/Rt46+Ww/Cx\\nGfVjI8YxZR7/CGft6IW6pJIIymwnaVotFOd0gZGoj+kvA3D31uHO+2JYpA2G8oQj\\n6Url/60zSh6IjBy5suV+ioP6LnjOlvi2KQjtHwzckxxIsv/CzJvcPUK4j4k8Jwuv\\nmyT6s7BFteY8dqyGbwaF75zh2OFno7YtHKtw+ktWG/zRUKHL31ztA+dukMOfNj1y\\nkUoNQjUz5yUKhhxCM7mS+8AGv6qWH9wRcewpqxG97YxBWGVtSs742sGShrzrLuP4\\nUtrmSd95CSxLe5RXbSbqWpBZ0Bm6fcTv1gw6R1exfQyIbdOS/lfC+HnnsWBRFgX9\\nKjQ3d253wDTe5X30FYRGvuxE2zyAczOuki4ZFYszViwGWH81xvjv8Iv/ypwgsua+\\nRc1SPIpC4EI38+N4hclbprv92x6CS+xlDGl12XK6kWE2v9ZqW95xX4sCzwARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8SFRERFo2UElZTEU3U0RGWVRDN1FQM1BNTklB\\nVEI1WFRFUExOUVFMTEpKV05QQ0lZV1paUlE3R05KWTJPRzVCTEFXMlo1NExQVkdO\\nNVNaWFdURkVXSExFS0pIVEZKSUpMNk9BUFlWUT0+iQI3BBMBCgAhBQJRkX6AAhsv\\nBQsJCAcCBhUICQoLAgQWAgMBAh4BAheAAAoJEEtk3eaziePUQ1cQAMg52/7/qN9t\\nkD7Qdb2X1Bpz+ZSHpWqqPpLWCWXwanZALFXommqTOxDHrsZahwaO4YkW1HsNzC9K\\nwdzhKeQfmtE8NBY53nKzdeLJ5HDFq9daa2CDzIwjiCWG7RC9cMYGxuI9RzvMPMxt\\nusHmR2HV+SCipMp+3mAyUaStkqWyeDHZBqPSw2zFy+sJ4t418yl4pf64eu1zKB7x\\nhpyMnoiSx0wYqwLlfSipDdk4+13eVjJgiIjPxmJYfkMRFEAZVVOPUXsNHUSV83OT\\nybnX4nE9+JlwQFrqgg8uLNyEJh+10WYO37Dt4gKy5iR2rJ316ANxe+g41Lxwz+VA\\nDgrJl/OpfhMqf3epwerzPnhqfpn6NgasyNdx+iHr/Z45jLSdGos89mJ3QJwcbjSi\\nwlDSNnMLtFmuxb1wtx9uaIcCIsIbqGAuaMiq7QDHdktp37cqfdCdS2RTGwqibz0V\\n/cWmHuF1r5jwUPUEGpXCaP6eI4J2zBG11BB7xLKwJmIPbrQuDScCinxmpQVN+BIy\\nSG9j4sd1z2CXKr3dyf++tyPol4+QTweTbpSxE+tOeokI3g9Pv/UqBc/lvmAqPJUR\\nvaq8HKGwHWe03mf6bH5CoXb76QlWVB7SbLju0Zct7B2Tt9+pDea5aivqMQJ78VPu\\nS4uu4UfPHvQU+V2sVvOsT127PyhysBvM\\n=n7gc\\n-----END
         PGP PUBLIC KEY BLOCK-----\\n\", \n        \"type\": \"PGP\"\n      }, \n      \"last_updated\":
-        \"2018-10-22T22:44:14.624438Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
-        2, \n      \"remove_star_url\": \"/api/v1/sources/26fe81f9-4d35-4999-9fd6-70963e9fd664/remove_star\",
-        \n      \"replies_url\": \"/api/v1/sources/26fe81f9-4d35-4999-9fd6-70963e9fd664/replies\",
-        \n      \"submissions_url\": \"/api/v1/sources/26fe81f9-4d35-4999-9fd6-70963e9fd664/submissions\",
-        \n      \"url\": \"/api/v1/sources/26fe81f9-4d35-4999-9fd6-70963e9fd664\",
-        \n      \"uuid\": \"26fe81f9-4d35-4999-9fd6-70963e9fd664\"\n    }, \n    {\n
-        \     \"add_star_url\": \"/api/v1/sources/7fc4c7ed-444d-4492-91e3-f2260cb5239b/add_star\",
+        \"2019-03-19T18:04:56.323543Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
+        2, \n      \"remove_star_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/remove_star\",
+        \n      \"replies_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/replies\",
+        \n      \"submissions_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions\",
+        \n      \"url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce\",
+        \n      \"uuid\": \"56208324-861b-4d2b-ac4e-555d516f24ce\"\n    }, \n    {\n
+        \     \"add_star_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/add_star\",
         \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
-        false, \n      \"journalist_designation\": \"fair dependence\", \n      \"key\":
-        {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFvOUr8BEADKa2dGTB4HWmaJ1GW38NSsG5gBnL5ff/bw+Ck/o3KFCWnSBhA6\\nLSbsAQRmjJyy3XM/MRDmnE+gdG6h0TerOSej6dEJtjDptmD2aO35qrp1qStbfo8k\\n6jA43syX0b87atMKCYvMO+LZPOTteFjlae4Jayg0ZEsuyST2Gjae+VuXF7TMoPf0\\nVdz+ZVhbJmulorN6sScRlCyxNW3uPR8e+iijQn2vJOKDP5HWny2JbpxEWbz5ltnN\\nM9zWkvbdJz4+YdUou0PKftM7QHtJlY5mooN96OqGxGUoN3DhBjWsJQKxLA6dRG2c\\nqu4AZ/g/dirsc8+PCBM7581ngsnJr6hh4l6n67rRPgl4kFttbAVrUPn1EyPbbV2u\\nKD6D3nqEm2F07+5R20+/F3gezLNl4xducv0zVjS+0lxXTKnnS1a++iqG4HfM8gbV\\nWp9OUxlcFoGBjKHknEYUYxvi510SvisuZzIgLy2XzQAofIk1JyyqI6HeX4S6qLW9\\nSEH/GsJmd+W+AP5zDCaUOrxdATqcIXKvfbvPECjbZsgp66p5pDf4aWHhQrDw2Vbr\\nag/RngRS3PdHomVQTE0iI7dqY5zmXAAkDYvsobh+0fSJ3xAofF9UXEFxICnbIit3\\ngpK824P/qTzdiY8s0iNkSZOwkQm5IAKllh3A/1gSsK0kDKY65wGwvFUFeQARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8U1JFTlo3T1U1NVQzSFFaQVpWTTJRSklCUlBG\\nVU1XNUdBUDNVUzNVMlFRREdQNVpTS0lTV1NMQVlVTzNVUFpXT0NYWTdRREJFUDdH\\nM1NDVUNSQVJVSENQREtFWlQ2R0pXVlBTWFFRUT0+iQI/BBMBCgApBQJbzlK/Ahsv\\nBQkB4JyBBwsJCAcDAgEGFQgCCQoLBBYCAwECHgECF4AACgkQ5/jlXeWpiJjfVA/+\\nO5ve6MyFPWT8DPb7UumsbP5iypQ2T4AwpyLHwWdV1Kcpxo6zStLjhAqX+sjivRG+\\nCvHOuduFBliKS47XoPfPdaZqKIKCz3w1Zmc3apBPfsNyvIZotuphT/3I7KJlD7nq\\noBQ77iybOiEZ/J/LhVuEb73n2EiKU5YmmfaHbG1M0NwXgdDPr3Frw1E4Hl/1iINF\\nGqrTGr9lnFxUSnyPvyeri4MQRJq2UH4RnVecam6PstqH79n5DHP2+Xw1sDzdszja\\nehQaMS2xNLa/U0KEYF8932ti2eqWzPKGaKe6aTQH0NPk89oBCeVOLQNnvsZlnkBp\\npWQRrSlBEOYThQMCs+2+Zn4pVv40wgccpfyepZVOf7l7JxyBm/V3MS8orbpVZ2Z2\\nmglEtNNfGnTdEZ2q7NrEMp27nze7BfP0TE5VZJ75ADZQubGhAWOEuXBiZlnqN1CE\\nDfg66Au38EhUJ95nwSoQHv9P+ipn2hvt/oAu2asV7zJUKIZcQJeMXOq2HoQ7vT8S\\nGXL/I78EIbwUJzZ0CtYuqRdmVPkJ6A7Ah1tFyvU8sDyfOuBrN8CSHyESaH9vTsFT\\nT6a24wHNGJmkEcDeypk5osa0/zmy14zVv4BbgLwBqSg/Fzzl0u14pzAO64KVaSWr\\neHt/yxwIukpnAp/REuPpLZ56AZLRIWBeOwDsSrQQOxg=\\n=g/yZ\\n-----END
+        false, \n      \"journalist_designation\": \"exasperating microscope\", \n
+        \     \"key\": {\n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmQINBFGRfoABEADKFFsV9PHRYbM9Dk4sDphjk/g8GEJky4kUzZwsD/Z/8DMRYJZw\\nJlkevyBDw5pZr/NhLtGOf085jSwG6O6nr7QTuJOI7Szh2Ib0r30jJwfL1LdWj/6N\\nf4iXVHzk817NSd//c2V7Qu59opHrxIUntfgiIEjj29EgpnoWWuJ4pe4gvfz/WS2G\\nKPPzFVm9CfZ8xc4YBl2l+rP1AIL+LdIWzcTq+/Y7f7nMdOsKYgaHnmjqZ1EIu0R9\\nR40hBDiqTpeoDhn7mwVG2N2Z+hxqHLxstr2m+o66p6xbo5yeWn/rQATueyd0lt/+\\nD/szhl78657zIYuVFMflQibbMz8hPubFVqEv2tiAp9Ul1sZfUPYr0bBjAXzMYllP\\nZDflpJF5AlDTNOr20zsAHUW8fYnm/YiPvM5Gjz9QfRTpa9C6yHceqk75Cr0AKB+q\\nhIQrt7B/J9EMOdkRyERZBewu4DcUHP+pRES+2at1C6d6Qunp6QQPcfILfJS6Bp3H\\nY4tbNl7neqhPQu/GsDD1CDoOiclOgLHUBnDH9ef80jGoCffO3qQDzckQ8S0xrORs\\nxaa6YSsj2u8XL7QbDe0WUFrypUE0Y/4kETw27qtH5xBISHcJbO5tLDllEHCJxAvX\\nNyIv6YvcpNXCh/F2dLP2x1vRt2xayLD5Xd+T/xtCaMdMWJiYu1Qj65uIMQARAQAB\\ntHxBdXRvZ2VuZXJhdGVkIEtleSA8T1lLRVdSNERKQ1EyTTRYWE5LNjMyNVAzU1pU\\nUkxQM1BBR09ZR01MWVBYTDdIWVpPVTRYRkFMSlFKNzJTQlJaTllRUE5CR0dJNlJX\\nVFdGUlhHS1hUUUtCN0VKNEE1UUI0MlpBUDNEST0+iQI3BBMBCgAhBQJRkX6AAhsv\\nBQsJCAcCBhUICQoLAgQWAgMBAh4BAheAAAoJEFOrutu9FeYMFFEP/22xHEk1Z4jB\\nXxSE7p8hWLaqJgD2BaSOBvqKU5hba91E/RvpTsGjbpmCaHlfLGL8haUQpSFxTW7o\\nR7kiVFdZYjuRCOoOITuH0P2vtVC0VE4/uE3MWF5UWgXeVp5SQz67kgtn9MBV4ZYK\\n1P6cRfZgHfLUsFtEP/U2Z6DjGe580GR9SivCbU2XC3rvcURjZqdvFkT7ABIgjME7\\n4ee0XCFs7oYnzXKZcY9ADrBTTt0d1c9FobavKKJwYs76ZF71WmkfcVEgTaT2DBg+\\nbpAz/3zSX6xSMFUu/VIQ7+iQYstTx/Un9VmV9BnnqwbMeennmQDpc9xC+80kvawD\\nsybSVogVMyjpCweCLYXiP/I1XDu2J3WZIQ1p701fgBvRp4SsPwXWJtE5j2DTQDq6\\noIh9bssdHu8hw0BHXkdprjHRij5Uek8evjbzz9gflat6Vlk2deq7KovFN6nR7xTE\\ngt2XBSoluUlVINN5ozgw/Il5tqDaZDv32hzU7wUmBeQPHvyrm6i9IhiOOTgQr7Wi\\n3DBrUpdXZZNxiKMEoLdAw7VJVXuvCEXELtQBfCoIbuGW7jdWeA+k8C9pxCrOG6O8\\ndNDP33U21/+N9XyMHBCF4TMiLJhhrcvV8/LtJ1t0id3oRm54iwuKel6KL0NQoIE4\\n5tICW7cN9qFg3719pl+SE+t2MqXqoaWO\\n=E8/J\\n-----END
         PGP PUBLIC KEY BLOCK-----\\n\", \n        \"type\": \"PGP\"\n      }, \n      \"last_updated\":
-        \"2018-10-22T22:44:16.419089Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
-        2, \n      \"remove_star_url\": \"/api/v1/sources/7fc4c7ed-444d-4492-91e3-f2260cb5239b/remove_star\",
-        \n      \"replies_url\": \"/api/v1/sources/7fc4c7ed-444d-4492-91e3-f2260cb5239b/replies\",
-        \n      \"submissions_url\": \"/api/v1/sources/7fc4c7ed-444d-4492-91e3-f2260cb5239b/submissions\",
-        \n      \"url\": \"/api/v1/sources/7fc4c7ed-444d-4492-91e3-f2260cb5239b\",
-        \n      \"uuid\": \"7fc4c7ed-444d-4492-91e3-f2260cb5239b\"\n    }\n  ]\n}\n"}
+        \"2019-03-19T18:04:58.189782Z\", \n      \"number_of_documents\": 0, \n      \"number_of_messages\":
+        2, \n      \"remove_star_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/remove_star\",
+        \n      \"replies_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/replies\",
+        \n      \"submissions_url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86/submissions\",
+        \n      \"url\": \"/api/v1/sources/0755725e-5f7e-436a-be9e-8ac400953b86\",
+        \n      \"uuid\": \"0755725e-5f7e-436a-be9e-8ac400953b86\"\n    }\n  ]\n}\n"}
     headers:
-      Content-Length: ['5232']
+      Content-Length: ['5214']
       Content-Type: [application/json]
-      Date: ['Mon, 22 Oct 2018 22:44:21 GMT']
-      Server: [Werkzeug/0.14.1 Python/2.7.6]
-      Set-Cookie: [js=eyJleHBpcmVzIjp7IiBkIjoiVHVlLCAyMyBPY3QgMjAxOCAwMDo0NDoyMCBHTVQifX0.Dq_kRQ.odwxnimAyJkaGlMzCFh2lQfcNHc;
-          HttpOnly; Path=/]
-      Vary: [Cookie]
+      Date: ['Tue, 19 Mar 2019 18:06:53 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU0MDI3NjkxOCwiaWF0IjoxNTQwMjQ4MTE4fQ.eyJpZCI6MX0.fygpQy3CxB1ulUWLFz2UdrtcBKHz-fk5gyRxbcSY720]
+      Authorization: [Token eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1MzA0NzYxMywiaWF0IjoxNTUzMDE4ODEzfQ.eyJpZCI6MX0.S1gNx3iwOmQgjjY7Pqhmkpbk3JCszng0eu31LbMOQhM]
       Connection: [keep-alive]
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://127.0.0.1:8081/api/v1/sources/26fe81f9-4d35-4999-9fd6-70963e9fd664/submissions
+    uri: http://127.0.0.1:8081/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions
   response:
-    body: {string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/26fe81f9-4d35-4999-9fd6-70963e9fd664/submissions/0f939198-de40-4689-bacd-983c1c678bbd/download\",
-        \n      \"filename\": \"1-edifying_skirl-msg.gpg\", \n      \"is_read\": false,
-        \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/26fe81f9-4d35-4999-9fd6-70963e9fd664\",
-        \n      \"submission_url\": \"/api/v1/sources/26fe81f9-4d35-4999-9fd6-70963e9fd664/submissions/0f939198-de40-4689-bacd-983c1c678bbd\",
-        \n      \"uuid\": \"0f939198-de40-4689-bacd-983c1c678bbd\"\n    }, \n    {\n
-        \     \"download_url\": \"/api/v1/sources/26fe81f9-4d35-4999-9fd6-70963e9fd664/submissions/9eb3e575-eec2-40b0-8a78-02317d60dce8/download\",
-        \n      \"filename\": \"2-edifying_skirl-msg.gpg\", \n      \"is_read\": false,
-        \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/26fe81f9-4d35-4999-9fd6-70963e9fd664\",
-        \n      \"submission_url\": \"/api/v1/sources/26fe81f9-4d35-4999-9fd6-70963e9fd664/submissions/9eb3e575-eec2-40b0-8a78-02317d60dce8\",
-        \n      \"uuid\": \"9eb3e575-eec2-40b0-8a78-02317d60dce8\"\n    }\n  ]\n}\n"}
+    body: {string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions/ae7e372b-21e5-4709-bb60-82ce5c6e13e3/download\",
+        \n      \"filename\": \"1-seamed_betel-msg.gpg\", \n      \"is_read\": false,
+        \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce\",
+        \n      \"submission_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions/ae7e372b-21e5-4709-bb60-82ce5c6e13e3\",
+        \n      \"uuid\": \"ae7e372b-21e5-4709-bb60-82ce5c6e13e3\"\n    }, \n    {\n
+        \     \"download_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions/f36c2b09-cbc3-4e14-aad3-a8b2c7d5fb80/download\",
+        \n      \"filename\": \"2-seamed_betel-msg.gpg\", \n      \"is_read\": false,
+        \n      \"size\": 604, \n      \"source_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce\",
+        \n      \"submission_url\": \"/api/v1/sources/56208324-861b-4d2b-ac4e-555d516f24ce/submissions/f36c2b09-cbc3-4e14-aad3-a8b2c7d5fb80\",
+        \n      \"uuid\": \"f36c2b09-cbc3-4e14-aad3-a8b2c7d5fb80\"\n    }\n  ]\n}\n"}
     headers:
-      Content-Length: ['1031']
+      Content-Length: ['1027']
       Content-Type: [application/json]
-      Date: ['Mon, 22 Oct 2018 22:44:21 GMT']
-      Server: [Werkzeug/0.14.1 Python/2.7.6]
-      Set-Cookie: [js=eyJleHBpcmVzIjp7IiBkIjoiVHVlLCAyMyBPY3QgMjAxOCAwMDo0NDoyMSBHTVQifX0.Dq_kRQ.hifQv31Sq4zxpiDgIxXxB1_hDSU;
-          HttpOnly; Path=/]
-      Vary: [Cookie]
+      Date: ['Tue, 19 Mar 2019 18:06:53 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
     status: {code: 200, message: OK}
 version: 1

--- a/data/test-get-submissions.yml
+++ b/data/test-get-submissions.yml
@@ -9,7 +9,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources
+    uri: http://127.0.0.1:8081/api/v1/sources
   response:
     body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/26fe81f9-4d35-4999-9fd6-70963e9fd664/add_star\",
         \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
@@ -52,7 +52,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources/26fe81f9-4d35-4999-9fd6-70963e9fd664/submissions
+    uri: http://127.0.0.1:8081/api/v1/sources/26fe81f9-4d35-4999-9fd6-70963e9fd664/submissions
   response:
     body: {string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/26fe81f9-4d35-4999-9fd6-70963e9fd664/submissions/0f939198-de40-4689-bacd-983c1c678bbd/download\",
         \n      \"filename\": \"1-edifying_skirl-msg.gpg\", \n      \"is_read\": false,

--- a/data/test-get-wrong-submissions.yml
+++ b/data/test-get-wrong-submissions.yml
@@ -9,7 +9,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources
+    uri: http://127.0.0.1:8081/api/v1/sources
   response:
     body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/e1f8baab-2a97-4590-8295-06f08d43731c/add_star\",
         \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
@@ -52,7 +52,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources/rofl-missing/submissions
+    uri: http://127.0.0.1:8081/api/v1/sources/rofl-missing/submissions
   response:
     body: {string: "{\n  \"error\": \"Not Found\", \n  \"message\": \"The requested
         URL was not found on the server.  If you entered the URL manually please check

--- a/data/test-reply-source-with-uuid.yml
+++ b/data/test-reply-source-with-uuid.yml
@@ -9,7 +9,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources
+    uri: http://127.0.0.1:8081/api/v1/sources
   response:
     body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/6c3a6a14-6751-4f5f-bba9-36e93943fc45/add_star\"\
         , \n      \"interaction_count\": 5, \n      \"is_flagged\": false, \n    \
@@ -80,7 +80,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: POST
-    uri: http://localhost:8081/api/v1/sources/6c3a6a14-6751-4f5f-bba9-36e93943fc45/replies
+    uri: http://127.0.0.1:8081/api/v1/sources/6c3a6a14-6751-4f5f-bba9-36e93943fc45/replies
   response:
     body: {string: "{\n  \"filename\": \"6-amendable_oxalate-reply.gpg\", \n  \"message\"\
         : \"Your reply has been stored\", \n  \"uuid\": \"e467868c-1fbb-4b5e-bca2-87944ea83855\"\

--- a/data/test-reply-source.yml
+++ b/data/test-reply-source.yml
@@ -9,7 +9,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources
+    uri: http://127.0.0.1:8081/api/v1/sources
   response:
     body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/6c3a6a14-6751-4f5f-bba9-36e93943fc45/add_star\"\
         , \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n    \
@@ -80,7 +80,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: POST
-    uri: http://localhost:8081/api/v1/sources/6c3a6a14-6751-4f5f-bba9-36e93943fc45/replies
+    uri: http://127.0.0.1:8081/api/v1/sources/6c3a6a14-6751-4f5f-bba9-36e93943fc45/replies
   response:
     body: {string: "{\n  \"filename\": \"5-amendable_oxalate-reply.gpg\", \n  \"message\"\
         : \"Your reply has been stored\", \n  \"uuid\": \"122f1449-2f4e-46c1-8605-0158fe9f3341\"\

--- a/data/test-setup.yml
+++ b/data/test-setup.yml
@@ -9,7 +9,7 @@ interactions:
       Content-Length: ['119']
       User-Agent: [python-requests/2.20.0]
     method: POST
-    uri: http://localhost:8081/api/v1/token
+    uri: http://127.0.0.1:8081/api/v1/token
   response:
     body: {string: "{\n  \"expiration\": \"2018-10-23T06:41:58.606548Z\", \n  \"token\":
         \"eyJhbGciOiJIUzI1NiIsImV4cCI6MTU0MDI3NjkxOCwiaWF0IjoxNTQwMjQ4MTE4fQ.eyJpZCI6MX0.fygpQy3CxB1ulUWLFz2UdrtcBKHz-fk5gyRxbcSY720\"\n}\n"}

--- a/data/test-setup.yml
+++ b/data/test-setup.yml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"one_time_code": "378795", "username": "journalist", "passphrase": "correct
-      horse battery staple profanity oil chewy"}'
+    body: '{"one_time_code": "278592", "passphrase": "correct horse battery staple
+      profanity oil chewy", "username": "journalist"}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
@@ -11,15 +11,12 @@ interactions:
     method: POST
     uri: http://127.0.0.1:8081/api/v1/token
   response:
-    body: {string: "{\n  \"expiration\": \"2018-10-23T06:41:58.606548Z\", \n  \"token\":
-        \"eyJhbGciOiJIUzI1NiIsImV4cCI6MTU0MDI3NjkxOCwiaWF0IjoxNTQwMjQ4MTE4fQ.eyJpZCI6MX0.fygpQy3CxB1ulUWLFz2UdrtcBKHz-fk5gyRxbcSY720\"\n}\n"}
+    body: {string: "{\n  \"expiration\": \"2019-03-20T02:56:30.121480Z\", \n  \"journalist_uuid\":
+        \"f775c4e9-e616-4fd4-9d87-e42cef293c3b\", \n  \"token\": \"eyJhbGciOiJIUzI1NiIsImV4cCI6MTU1MzA1MDU5MCwiaWF0IjoxNTUzMDIxNzkwfQ.eyJpZCI6MX0.16UNxpkI4yOEI6Jqsz3hrmjhgqSiw61xAENb654nRX0\"\n}\n"}
     headers:
-      Content-Length: ['188']
+      Content-Length: ['250']
       Content-Type: [application/json]
-      Date: ['Mon, 22 Oct 2018 22:41:58 GMT']
-      Server: [Werkzeug/0.14.1 Python/2.7.6]
-      Set-Cookie: [js=eyJleHBpcmVzIjp7IiBkIjoiVHVlLCAyMyBPY3QgMjAxOCAwMDo0MTo1OCBHTVQifX0.Dq_jtg.QIkHRFQrSFIxNmv3awdJjiXXT18;
-          HttpOnly; Path=/]
-      Vary: [Cookie]
+      Date: ['Tue, 19 Mar 2019 18:56:30 GMT']
+      Server: [Werkzeug/0.14.1 Python/2.7.12]
     status: {code: 200, message: OK}
 version: 1

--- a/data/test-star-add-remove.yml
+++ b/data/test-star-add-remove.yml
@@ -9,7 +9,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources
+    uri: http://127.0.0.1:8081/api/v1/sources
   response:
     body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/d9235b36-b3d4-49f1-b5df-dea96179342c/add_star\",
         \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":
@@ -53,7 +53,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: POST
-    uri: http://localhost:8081/api/v1/sources/d9235b36-b3d4-49f1-b5df-dea96179342c/add_star
+    uri: http://127.0.0.1:8081/api/v1/sources/d9235b36-b3d4-49f1-b5df-dea96179342c/add_star
   response:
     body: {string: "{\n  \"message\": \"Star added\"\n}\n"}
     headers:
@@ -76,7 +76,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: DELETE
-    uri: http://localhost:8081/api/v1/sources/d9235b36-b3d4-49f1-b5df-dea96179342c/remove_star
+    uri: http://127.0.0.1:8081/api/v1/sources/d9235b36-b3d4-49f1-b5df-dea96179342c/remove_star
   response:
     body: {string: "{\n  \"message\": \"Star removed\"\n}\n"}
     headers:
@@ -98,7 +98,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.20.0]
     method: GET
-    uri: http://localhost:8081/api/v1/sources
+    uri: http://127.0.0.1:8081/api/v1/sources
   response:
     body: {string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/d9235b36-b3d4-49f1-b5df-dea96179342c/add_star\",
         \n      \"interaction_count\": 4, \n      \"is_flagged\": false, \n      \"is_starred\":

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -23,7 +23,7 @@ class TestAPI(unittest.TestCase):
         self.totp = pyotp.TOTP("JHCOGO7VCER3EJ4L")
         self.username = "journalist"
         self.password = "correct horse battery staple profanity oil chewy"
-        self.server = "http://localhost:8081/"
+        self.server = "http://127.0.0.1:8081/"
         self.api = API(self.server, self.username, self.password, str(self.totp.now()))
         for i in range(3):
             try:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,6 +17,9 @@ from sdclientapi.sdlocalobjects import (
 from utils import load_auth, save_auth
 
 
+NUM_REPLIES_PER_SOURCE = 2
+
+
 class TestAPI(unittest.TestCase):
     @vcr.use_cassette("data/test-setup.yml")
     def setUp(self):
@@ -45,7 +48,11 @@ class TestAPI(unittest.TestCase):
     @vcr.use_cassette("data/test-get-sources.yml")
     def test_get_sources(self):
         sources = self.api.get_sources()
-        self.assertEqual(len(sources), 2)
+        for source in sources:
+            # Assert expected fields are present
+            assert source.journalist_designation
+            assert source.uuid
+            assert source.last_updated
 
     @vcr.use_cassette("data/test-star-add-remove.yml")
     def test_star_add_remove(self):
@@ -84,11 +91,14 @@ class TestAPI(unittest.TestCase):
         s = self.api.get_sources()[0]
 
         subs = self.api.get_submissions(s)
-        self.assertEqual(len(subs), 2)
+        for submission in subs:
+            assert submission.filename
 
     @vcr.use_cassette("data/test-get-submission.yml")
     def test_get_submission(self):
-        s = self.api.get_sources()[0]
+        # Get a source with submissions
+        source_uuid = self.api.get_all_submissions()[0].source_uuid
+        s = self.api.get_source(Source(uuid=source_uuid))
 
         subs = self.api.get_submissions(s)
         sub = self.api.get_submission(subs[0])
@@ -96,7 +106,9 @@ class TestAPI(unittest.TestCase):
 
     @vcr.use_cassette("data/test-get-submission.yml")
     def test_get_submission_from_string(self):
-        s = self.api.get_sources()[0]
+        # Get a source with submissions
+        source_uuid = self.api.get_all_submissions()[0].source_uuid
+        s = self.api.get_source(Source(uuid=source_uuid))
 
         subs = self.api.get_submissions(s)
         sub = self.api.get_submission_from_string(subs[0].uuid, s.uuid)
@@ -112,7 +124,8 @@ class TestAPI(unittest.TestCase):
     @vcr.use_cassette("data/test-get-all-submissions.yml")
     def test_get_all_submissions(self):
         subs = self.api.get_all_submissions()
-        self.assertEqual(len(subs), 4)
+        for submission in subs:
+            assert submission.filename
 
     @vcr.use_cassette("data/test-flag-source.yml")
     def test_flag_source(self):
@@ -124,29 +137,35 @@ class TestAPI(unittest.TestCase):
 
     @vcr.use_cassette("data/test-delete-source.yml")
     def test_delete_source(self):
+        number_of_sources_before = len(self.api.get_sources())
+
         s = self.api.get_sources()[0]
         self.assertTrue(self.api.delete_source(s))
 
-        # Now there should be one source left
+        # Now there should be one less source
         sources = self.api.get_sources()
-        self.assertEqual(len(sources), 1)
+        self.assertEqual(len(sources), number_of_sources_before - 1)
 
     @vcr.use_cassette("data/test-delete-source.yml")
     def test_delete_source_from_string(self):
+        number_of_sources_before = len(self.api.get_sources())
+
         s = self.api.get_sources()[0]
         self.assertTrue(self.api.delete_source_from_string(s.uuid))
 
-        # Now there should be one source left
+        # Now there should be one less source
         sources = self.api.get_sources()
-        self.assertEqual(len(sources), 1)
+        self.assertEqual(len(sources), number_of_sources_before - 1)
 
     @vcr.use_cassette("data/test-delete-submission.yml")
     def test_delete_submission(self):
+        number_of_submissions_before = len(self.api.get_all_submissions())
+
         subs = self.api.get_all_submissions()
         self.assertTrue(self.api.delete_submission(subs[0]))
         new_subs = self.api.get_all_submissions()
-        # We now should have 3 submissions
-        self.assertEqual(len(new_subs), 3)
+        # We now should have 1 less submission
+        self.assertEqual(len(new_subs), number_of_submissions_before - 1)
 
         # Let us make sure that sub[0] is not there
         for s in new_subs:
@@ -154,14 +173,16 @@ class TestAPI(unittest.TestCase):
 
     @vcr.use_cassette("data/test-delete-submission-from-string.yml")
     def test_delete_submission_from_string(self):
+        number_of_submissions_before = len(self.api.get_all_submissions())
+
         s = self.api.get_sources()[0]
 
         subs = self.api.get_submissions(s)
 
         self.assertTrue(self.api.delete_submission(subs[0]))
         new_subs = self.api.get_all_submissions()
-        # We now should have 3 submissions
-        self.assertEqual(len(new_subs), 3)
+        # We now should have 1 less submission
+        self.assertEqual(len(new_subs), number_of_submissions_before - 1)
 
         # Let us make sure that sub[0] is not there
         for s in new_subs:
@@ -230,7 +251,7 @@ class TestAPI(unittest.TestCase):
     def test_get_replies_from_source(self):
         s = self.api.get_sources()[0]
         replies = self.api.get_replies_from_source(s)
-        self.assertEqual(len(replies), 2)
+        self.assertEqual(len(replies), NUM_REPLIES_PER_SOURCE)
 
     @vcr.use_cassette("data/test-get-reply-from-source.yml")
     def test_get_reply_from_source(self):
@@ -247,8 +268,9 @@ class TestAPI(unittest.TestCase):
 
     @vcr.use_cassette("data/test-get-all-replies.yml")
     def test_get_all_replies(self):
+        num_sources = len(self.api.get_sources())
         replies = self.api.get_all_replies()
-        self.assertEqual(len(replies), 4)
+        self.assertEqual(len(replies), NUM_REPLIES_PER_SOURCE * num_sources)
 
     @vcr.use_cassette("data/test-download-reply.yml")
     def test_download_reply(self):
@@ -269,7 +291,9 @@ class TestAPI(unittest.TestCase):
     def test_delete_reply(self):
         r = self.api.get_all_replies()[0]
 
+        number_of_replies_before = len(self.api.get_all_replies())
+
         self.assertTrue(self.api.delete_reply(r))
 
-        # We deleted one, so there must be 3 replies left
-        self.assertEqual(len(self.api.get_all_replies()), 3)
+        # We deleted one, so there must be 1 less reply now
+        self.assertEqual(len(self.api.get_all_replies()), number_of_replies_before - 1)


### PR DESCRIPTION
the idea in this PR is to add a circle CI job that runs nightly and (I can be convinced the latter is a bad idea) on each PR. the circle CI job will run the API tests against the server container

that way if there's a discrepancy between API and SDK, we can detect it (ref: #55)

(btw I did this in a fork so that my frequent force pushing doesn't create a billion notifications)

