### PR TITLE
pin setup.py install_requires to match Pipfile.lock

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,10 @@ jobs:
       - run:
           name: Check for known CVEs
           command: pipenv check
+      - run:
+          name: Ensure requiremnts are pinned to mathc Pipfile.lock
+          command: make check-dependencies
+
   test-against-latest-api:
     working_directory: ~/project
     machine:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include sdclientapi/*.py
 include README.md
 include LICENSE
+include requirements.txt
 include setup.py

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL=/bin/bash
 DEFAULT_GOAL: help
 OPEN=$(word 1, $(wildcard /usr/bin/xdg-open /usr/bin/open))
 
@@ -21,6 +22,13 @@ mypy: ## Run the mypy typechecker
 
 .PHONY: check
 check: lint mypy test ## Run all checks and tests
+
+.PHONY: check-dependencies
+check-dependencies: ## Check that the dependencies specified in Pipfile.lock are the same as setup.py
+	@pipenv --rm && \
+		pipenv sync && \
+		cmp -s <(pipenv run pip freeze) requirements.txt || \
+			{ diff <(pipenv run pip freeze) requirements.txt ; exit 1 ; }
 
 .PHONY: open-coverage-report
 open-coverage-report: ## Open the coverage report in your browser

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+certifi==2018.11.29
+chardet==3.0.4
+idna==2.7
+requests==2.20.0
+urllib3==1.24

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,9 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
+with open("requirements.txt") as f:
+    install_requires = f.read().split("\n")
+
 setuptools.setup(
     name="securedrop-sdk",
     version="0.0.6",
@@ -12,7 +15,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     license="GPLv3+",
-    install_requires=["requests", "urllib3"],
+    install_requires=install_requires,
     python_requires=">=3.5",
     url="https://github.com/freedomofpress/securedrop-sdk",
     packages=setuptools.find_packages(exclude=["docs", "tests"]),


### PR DESCRIPTION
Fixes #66

This ensure that the exact versions of all dependencies (and transitive dependencies) from `Pipfile.lock` are the same as what is specified by `install_requires` in `setup.py`. This is to make sure we're not running CI against pinned versions that actually vary when we install the SDK in the client.