### PR TITLE
Skip locking of Pipenv in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,11 +27,10 @@ jobs:
             - "/usr/local/lib/python3.5/site-packages"
       - run:
           name: Run linters
-          command: pipenv run make check
+          command: pipenv run make lint mypy
       - run:
           name: Run tests
-          command: |
-            pipenv run python -m unittest discover -v tests/
+          command: pipenv run make test
       - run:
           name: Check for known CVEs
           command: pipenv check
@@ -75,7 +74,7 @@ jobs:
           name: Remove VCR cassettes and run tests against latest API
           command: |
             rm data/*.yml  # Removing VCR cassettes
-            pipenv run python -m unittest discover -v tests/
+            pipenv run make test
 workflows:
   version: 2
   securedrop_ci:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,8 @@ jobs:
           command: |
             set -e
             sudo pip install pipenv
-            pipenv sync --dev
+            pipenv install --dev --skip-lock
+            pipenv run pip freeze
       - save_cache:
           key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
           paths:
@@ -46,7 +47,8 @@ jobs:
           name: Install dependencies
           command: |
             sudo pip install pipenv
-            pipenv install -d
+            pipenv install --dev --skip-lock
+            pipenv run pip freeze
       - run:
           name: Download SecureDrop server code
           command: git clone https://github.com/freedomofpress/securedrop.git


### PR DESCRIPTION
fixes #66

This skips locking the dependencies in CI so we aren't only testing against one version of our dependencies when downstream consumers of this library might not pin to the same versions. This small amount of variance will help us catch bugs.

This also adds a change to how we call the unit test. We now use `make test` so it exactly matches the dev env. Additionally, we called `make check` for linting then `make test` to run the unit tests. However, `make check` has as a dependency the `test` target, so we were running the unit tests twice.