### PR TITLE
Extended dev docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Python SDK for SecureDrop
+# Python SDK for SecureDrop
 
 [![CircleCI](https://circleci.com/gh/freedomofpress/securedrop-sdk/tree/master.svg?style=svg)](https://circleci.com/gh/freedomofpress/securedrop-sdk/tree/master)
 
@@ -8,29 +8,17 @@ The SDK is currently used by the [SecureDrop Client](https://github.com/freedomo
 
 **IMPORTANT:** This project is still under active development. We do not recommend using it in any production context.
 
-### Development
+## Developer Quick Start
 
-This project uses [pipenv](https://docs.pipenv.org) to manage all dependencies.
-This is a Python 3 project. When using `pipenv` locally, ensure you used the `--keep-outdated` flag to prevent
-dependencies from being unnecessarily upgraded during normal development.
+```bash
+pip install -U pipenv
+pipenv sync --dev
+pipenv shell
+make test
+```
 
-We cover all the API calls supported by the SecureDrop Journalist Interface API.
+More complete documentation can be found in the [`docs`](./docs) directory.
 
-Additional tests will be added in future.
+## License
 
-### Testing
-
-To test the code, you will need to run the SecureDrop `make dev` command on the same system. The test suite for
-this project will test against that development container.
-
-### Release
-
-To make a release, you should:
-
-1. Update the version in `setup.py`.
-2. Update the changelog.
-3. Commit the changes, and `git tag`.
-4. Create a PR, push the new tag, and get the PR reviewed and merged into `master`.
-5. Push the new release to the PSF's PyPI [following this documentation](https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives).
-
-### License: GPLv3+
+The Python SecureDrop SDK is licensed in the GPLv3. See [`LICENSE`](./LICENSE) for more details.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -7,7 +7,7 @@ the project.
 Git clone the project repo, and use the following command to create a new dev
 environment. The second command is to enable the virtual environment.
 
-::
+.. code:: sh
 
     pipenv sync --dev
     pipenv shell
@@ -26,13 +26,13 @@ allow to have real token from the server.
 
 To run all the test cases, use the following command.
 
-::
+.. code:: sh
 
-    $ python -m unittest discover -v tests/
+    make test
 
 To run a single test, use this following command, replace the test case name
 at the end.
 
-::
+.. code:: sh
 
-    $ python -m unittest -v tests.test_api.TestAPI.test_error_unencrypted_reply
+    make test TESTS=tests/test_api.py::TestAPI::test_error_unencrypted_reply

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -17,11 +17,11 @@ environment. The second command is to enable the virtual environment.
 Testing
 ========
 
-The `tests` directory contains the test cases for API. We are using `vcrpy
+The ``tests`` directory contains the test cases for API. We are using `vcrpy
 <http://vcrpy.readthedocs.io/en/latest/>`_ to mock out the test calls.
 
 If you want to run the tests against an actual SecureDrop environment, please
-comment out the `@vcr` decorator of the `setUp` method in the test. This will
+comment out the ``@vcr`` decorator of the ``setUp`` method in the test. This will
 allow to have real token from the server.
 
 To run all the test cases, use the following command.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -1,8 +1,11 @@
 Development
 ============
 
-We are using `pipenv <https://docs.pipenv.org>`_ to manage the dependencies of
-the project.
+This project uses `pipenv <https://docs.pipenv.org>`_ to manage all dependencies.
+This is a Python 3 project. When using ``pipenv`` locally, ensure you used the ``--keep-outdated``
+flag to prevent dependencies from being unnecessarily upgraded during normal development.
+
+We cover all the API calls supported by the SecureDrop Journalist Interface API.
 
 Git clone the project repo, and use the following command to create a new dev
 environment. The second command is to enable the virtual environment.
@@ -13,16 +16,13 @@ environment. The second command is to enable the virtual environment.
     pipenv shell
 
 
-
 Testing
 ========
 
-The ``tests`` directory contains the test cases for API. We are using `vcrpy
-<http://vcrpy.readthedocs.io/en/latest/>`_ to mock out the test calls.
-
-If you want to run the tests against an actual SecureDrop environment, please
-comment out the ``@vcr`` decorator of the ``setUp`` method in the test. This will
-allow to have real token from the server.
+The tests are located in the ``tests`` directory. This project uses `vcrpy
+<http://vcrpy.readthedocs.io/en/latest/>`_ to record and then reply the API calls so that
+developers will have repeatable results so that they may work offline. ``vcrpy`` stores YAML
+recordings of the API calls in the ``data`` directory. 
 
 To run all the test cases, use the following command.
 
@@ -30,9 +30,27 @@ To run all the test cases, use the following command.
 
     make test
 
-To run a single test, use this following command, replace the test case name
-at the end.
+To run a single test, use this following command, replace the test case name at the end.
 
 .. code:: sh
 
     make test TESTS=tests/test_api.py::TestAPI::test_error_unencrypted_reply
+
+
+To test against a live development server, you will need to run the SecureDrop developent
+container from the main SecureDrop repository on your host. This can be done via ``make -C securedrop dev``.
+
+In this repo, comment out the ``@vcr`` decorator of the ``setUp`` method and which ever tests
+you want to run. If you want to re-run all tests against the API, remove all the ``.yml`` files
+in the ``data`` directory. 
+
+Releasing
+=========
+
+To make a release, you should:
+
+1. Update the version in ``setup.py``
+2. Update the changelog
+3. Commit the changes, and ``git tag``.
+4. Create a PR, push the new tag, and get the PR reviewed and merged into ``master``.
+5. Push the new release to the PSF's PyPI `following this documentation <https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,15 +3,28 @@
 SecureDrop SDK Documentation
 ============================
 
+
+Developer Quick Start
+---------------------
+
+.. code:: sh
+
+    pip install -U pipenv
+    pipenv sync --dev
+    pipenv shell
+    make test
+
+Table of Contents
+-----------------
+
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
 
    development
 
 
 Indices and tables
-==================
+------------------
 
 * :ref:`genindex`
 * :ref:`modindex`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,10 +1,7 @@
-.. sdconfigapi documentation master file, created by
-   sphinx-quickstart on Thu Aug  2 16:55:50 2018.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+.. sdconfigapi documentation master file
 
-Welcome to sdconfigapi's documentation!
-=======================================
+SecureDrop SDK Documentation
+============================
 
 .. toctree::
    :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,6 @@ SecureDrop SDK Documentation
    :maxdepth: 2
    :caption: Contents:
 
-   install
    development
 
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,4 +1,0 @@
-Installation
-============
-
-TODO


### PR DESCRIPTION
Towards #6

Also this trims the `README` and makes a note to the user to check the `docs` dir. We should avoid duplicating docs into multiple places where possible.