### PR TITLE
securedrop-sdk 0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+0.0.11
+------
+
+* Expose ETags in submission and reply downloads (#96).
+* Update tests and test data for first and last name (#92).
+* Bug fix: Ensure RequestTimeoutError is raised for submission and reply downloads (#95).
+
+0.0.10
+------
+
+* Support logout endpoint (#88).
+
 0.0.9
 -----
 

--- a/README.md
+++ b/README.md
@@ -103,14 +103,13 @@ system.
 
 To make a release, you should:
 
-1. Create a branch named "release-[VERSION]"
+1. Create a branch named `release/$new_version_number`
 2. Update `CHANGELOG.md` and `setup.py`
 3. Commit the changes.
 4. Create a PR and get the PR reviewed and merged into ``master``.
-5. ``git tag`` and push the new tag.
+5. ``git tag $new_version_number`` and push the new tag.
 6. Checkout the new tag locally.
 7. Push the new release source tarball to the PSF's PyPI [following this documentation](https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives).
-
 8. If you want to publish the new SDK release to the FPF PyPI mirror, Hop over to the the `securedrop-debian-packaging` repo and follow the [build-a-package](https://github.com/freedomofpress/securedrop-debian-packaging/blob/master/README.md#build-a-package) instructions to push the package up to our PyPI mirror: https://pypi.org/simple
 
 # Contributing

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="securedrop-sdk",
-    version="0.0.10",
+    version="0.0.11",
     author="Freedom of the Press Foundation",
     author_email="securedrop@freedom.press",
     description="Python client API to access SecureDrop Journalist REST API",


### PR DESCRIPTION
We need this new SDK release to complete https://github.com/freedomofpress/securedrop-client/issues/383 and https://github.com/freedomofpress/securedrop-client/issues/384 for this sprint

This PR is step 4 in the securedrop-sdk release guide: https://github.com/freedomofpress/securedrop-sdk#releasing