### PR TITLE
[wip] ci: increase build timeout to 20 minutes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
       - run:
           name: Wait for server to be up and for test sources to load
           command: |
-            dockerize -wait tcp://127.0.0.1:8080 -timeout 15m
+            dockerize -wait tcp://127.0.0.1:8080 -timeout 20m
             sleep 30
       - run:
           name: Remove VCR cassettes and run tests against latest API


### PR DESCRIPTION
`test-against-latest-api` CI job keeps failing due to container build timeout, this PR is a test to see if this resolves