### PR TITLE
Update qrexec policy keyword characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ in **dom0**.
 
 ```
 sd-svs sd-journalist allow
-$anyvm $anyvm deny
+@anyvm @anyvm deny
 ```
 
 The above mentioned setup can also be created using `securedrop-workstation` project.


### PR DESCRIPTION
Qubes advises that all qrexec policy keywords should now begin with @ (instead of $).

For context, see the security bulletin here: https://github.com/QubesOS/qubes-secpack/blob/master/QSBs/qsb-038-2018.txt