### PR TITLE
fix 109, rework exception handling

### DIFF
--- a/sdclientapi/__init__.py
+++ b/sdclientapi/__init__.py
@@ -1,4 +1,5 @@
 import configparser
+import http
 import json
 import os
 import requests
@@ -243,8 +244,12 @@ class API:
         except json.decoder.JSONDecodeError:
             raise BaseError("Error in parsing JSON")
 
-        if "error" in data:
+        if "error" in data and status_code == http.HTTPStatus.GATEWAY_TIMEOUT:
+            raise RequestTimeoutError
+        elif "error" in data and status_code == 403:
             raise AuthError(data["error"])
+        elif "error" in data:
+            raise BaseError(data["error"])
 
         sources = data["sources"]
         result = []  # type: List[Source]

--- a/sdclientapi/sdlocalobjects.py
+++ b/sdclientapi/sdlocalobjects.py
@@ -5,7 +5,12 @@ if typing.TYPE_CHECKING:
 
 
 class BaseError(Exception):
-    pass
+    """For generic errors not covered by other exceptions"""
+    def __init__(self, message: typing.Optional[str] = None) -> None:
+        self.msg = message
+
+    def __str__(self) -> str:
+        return repr(self.msg)
 
 
 class ReplyError(BaseError):

--- a/tests/test_apiproxy.py
+++ b/tests/test_apiproxy.py
@@ -1,4 +1,6 @@
 import datetime
+import http
+import json
 import os
 import pyotp
 import pytest
@@ -362,3 +364,14 @@ def test_download_submission_timeout(mocker):
     with pytest.raises(RequestTimeoutError):
         s = Submission(uuid="climateproblem")
         api.download_submission(s)
+
+
+def test_download_get_sources_error_request_timeout(mocker):
+    api = API("mock", "mock", "mock", "mock", True)
+    mocker.patch("sdclientapi.json_query",
+                 return_value=(
+                    json.dumps({"body": json.dumps({"error": "wah"}),
+                                "status": http.HTTPStatus.GATEWAY_TIMEOUT,
+                                "headers": "foo"})))
+    with pytest.raises(RequestTimeoutError):
+        api.get_sources()


### PR DESCRIPTION
Fixes #109 

Right now we have these status codes provided by the `securedrop-proxy` qrexec service: https://github.com/freedomofpress/securedrop-proxy/blob/21c2963ffb383092142bafdda6fd5886857b675d/securedrop_proxy/proxy.py#L263 and https://github.com/freedomofpress/securedrop-proxy/blob/21c2963ffb383092142bafdda6fd5886857b675d/securedrop_proxy/proxy.py#L270 which we should be passing through for clients to use. 

(btw, we _will_ probably treat a `ServerConnectionError` the same as a `RequestTimeoutError` from `securedrop-client`, but we shouldn't make them the same from the SDK since we might want to customize behavior later)

To test:
1. Run client on branch [use-sdk-serverconnectionerror](https://github.com/freedomofpress/securedrop-client/tree/use-sdk-serverconnectionerror)
2. Install this branch of securedrop-sdk instead of 0.0.12
3. Open client, connect, wait for sync. It should succeed.
4. Pause staging server.
5. You should NOT see the logout window come up as described [here](https://github.com/freedomofpress/securedrop-client/pull/739#issuecomment-582686037). 
6. Send a reply.
7. See "The SecureDrop server cannot be reached" with a retry button. 

Once this is merged we can make an sdk release