### PR TITLE
securedrop-sdk 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.1.0
+-----
+
+* Pass timeout value to the proxy (#117).
+* Update PyYAML to 5.3.1 (#120).
+
 0.0.13
 ------
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ This SDK provides a convenient Python interface to the [SecureDrop Journalist In
 
 The SDK is currently used by the [SecureDrop Client](https://github.com/freedomofpress/securedrop-client) that is a component of the SecureDrop Workstation. When used in Qubes OS, the SDK uses the [securedrop-proxy](https://github.com/freedomofpress/securedrop-proxy) service, as the VM which runs the client does not have network access by design.
 
-**IMPORTANT:** This project is still under active development. We do not recommend using it in any production context.
-
 # Development
 
 ## Quick Start
@@ -112,7 +110,7 @@ To make a release, you should:
 4. Create a PR and get the PR reviewed and merged into ``master``.
 5. ``git tag $new_version_number`` and push the new tag.
 6. Checkout the new tag locally.
-7. Push the new release source tarball to the PSF's PyPI [following this documentation](https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives).
+7. Push the new release source tarball to the PSF's PyPI [following this documentation](https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives). Do not upload the wheel (by deleting it from your `dist/` directory prior to upload).
 8. If you want to publish the new SDK release to the FPF PyPI mirror, Hop over to the the `securedrop-debian-packaging` repo and follow the [build-a-package](https://github.com/freedomofpress/securedrop-debian-packaging/blob/master/README.md#build-a-package) instructions to push the package up to our PyPI mirror: https://pypi.org/simple
 
 # Contributing

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="securedrop-sdk",
-    version="0.0.13",
+    version="0.1.0",
     author="Freedom of the Press Foundation",
     author_email="securedrop@freedom.press",
     description="Python client API to access SecureDrop Journalist REST API",
@@ -17,7 +17,6 @@ setuptools.setup(
     url="https://github.com/freedomofpress/securedrop-sdk",
     packages=setuptools.find_packages(exclude=["docs", "tests"]),
     classifiers=(
-        "Development Status :: 3 - Alpha",
         "Programming Language :: Python :: 3",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",


### PR DESCRIPTION
I'm preparing this release as we'll need to include it as a new dependency in `securedrop-client` for its next release.

## Testing

I've tested it by using `master` of `securedrop-client` with this branch of the SDK and the latest nightly of `securedrop-proxy` (https://apt-test.freedom.press/pool/main/s/securedrop-proxy/securedrop-proxy_0.2.1-dev-20200427-060417%2Bbuster_all.deb). I've verified I can successfully sync with a staging server with 1000 sources and done basic network operations (sent a reply successfully, downloaded a file/message/reply successfully).

## Next steps

Once this is merged, I'll do the next steps which are: 
1. Push a tag signed with the release key
2. Upload the source tarball to PyPI
3. Upload the source tarball and wheel to our pip mirror

This also contains a change towards https://github.com/freedomofpress/securedrop-debian-packaging/issues/144 (no longer uploading wheels to PyPI)
