### PR TITLE
Fix TOTP retry logic, improve cassette handling; document

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,22 @@ The steps to generate new cassettes are split into two sections based on communi
     NUM_SOURCES=5 make dev
     ```
 
-2. [Skip if adding a new test] Delete the cassettes you wish to regenerate or just delete all yaml files by running:
+2. Delete the cassettes you wish to regenerate or just delete all yaml files by running:
 
     ```bash
     rm data/*.yml
     ```
+
+   If you are only adding a new test and not modifying existing ones, you can
+   skip this step, but you still need to remove the authentication setup during
+   cassette generation. Otherwise you will get 403 errors for API endpoints that
+   require a valid token. Remove the setup cassette by running:
+
+   ```bash
+   rm data/test-setup.yml
+   ```
+
+   (You can reinstate the unmodified version later.)
 
 3. Generate new cassettes that make API calls over HTTP by running:
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ name=sd-dev-proxy
 sd-dev sd-dev-proxy allow
 ```
 
-8. Modify `/etc/qubes-rpc/qubes.Filecopy` in **dom0** by adding the following line so that the proxy can send files over qrexec to the sdk:
+8. Modify `/etc/qubes-rpc/policy/qubes.Filecopy` in **dom0** by adding the following line to the top of the file so that the proxy can send files over qrexec to the sdk:
 
 ```
 sd-dev-proxy sd-dev allow

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -123,16 +123,3 @@ def load_auth():
 def save_auth(token):
     with open("testtoken.json", "w") as fobj:
         json.dump(token, fobj)
-
-
-def load_auth_for_http():
-    "Helper function to load token"
-    if os.path.exists("testtoken_http.json"):
-        with open("testtoken_http.json") as fobj:
-            return json.load(fobj)
-    return None
-
-
-def save_auth_for_http(token):
-    with open("testtoken_http.json", "w") as fobj:
-        json.dump(token, fobj)


### PR DESCRIPTION
As part of working on #134 I noticed that `setUp` in `test_api.py` was not working as expected: when regenerating the cassette, authentication would either succeed, or it would fail and keep failing. The TOTP code was not successfully re-retrieved.

The logic does not work as currently written because 1) it would keep using the same TOTP code if it actually looped, which it doesn't because, 2) it will quietly exit the loop after sleeping.

Because we're already using a cassette to record the API response(s), there's really no reason for an additional utility method to stash and load it -- we just need to make sure we don't run sleeps when we're in playback mode.

Also fixes a path error for the RPC policy changes documented in the README.

## Status

Ready for review. CI will fail until #133 and #136 land.

## Test plan

### Reproduce the error

On the `main` branch, run the following command in your virtualenv:

```bash
rm data/test-setup.yml && python -m pytest -v -k test_api_auth
```

What this command does: remove the setup cassette and attempt to obtain a fresh, valid API token

- [ ] Observe: Expected behavior: test success. Actual behavior (usually, initially): test success

Run it again once or twice, in quick succession.

- [ ] Observe: Expected behavior: test success. Actual behavior: long sleep, test failure.

### Reproduce the fix

Perform the same steps on this branch.
- [ ] Observe that the error no longer occurs, and that the API test successfully completes.

###  No sleep during playback

Check that the file `data/test-setup.yml` still contains a 403 response from the previous run. If not, re-run until you observe a sleep, then preserve `data/test-setup.yml` with a 403 in it.

Run all tests from the cassettes (reminded that dev env needs to be restarted between full test runs, due to the deletion related tests):

```
make test TESTS=tests/test_api.py
```

- [ ] Observe that all tests pass
- [ ] Observe that in spite of the 403 in the previous recorded auth response, there is no 31 second sleep during test execution.