### PR TITLE
Document that making RPC policy changes will cause tests to fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ name=sd-dev-proxy
 sd-dev sd-dev-proxy allow
 ```
 
+**NOTE:** You may want to switch back to the RPC configuration files in their as-provisioned state before a `make test` run in `dom0`, as this and the following change to the RPC policies will break the strict validation of the RPC policies that is one of those tests.
+
 8. Modify `/etc/qubes-rpc/policy/qubes.Filecopy` in **dom0** by adding the following line to the top of the file so that the proxy can send files over qrexec to the sdk:
 
 ```


### PR DESCRIPTION
While the failure output of those tests is fairly explanatory, it's still best to document the behavior here so that devs know to potentially toggle dev RPC settings before running tests. (We could make those tests more lenient, of course, but right now they are extremely rigid.)