### PR TITLE
ci: run nightly job on default (main) branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,6 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
     jobs:
       - test-against-latest-api


### PR DESCRIPTION
Closes #144 
### Test plan: 
- [ ] `main` is the default branch of this repository
- [ ] we want to run nightly ci job on this `main` branch