### PR TITLE
Move redundant code into shared test class

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,10 +1,7 @@
-import datetime
 import hashlib
-import os
 import shutil
 import tempfile
 import time
-import unittest
 
 import pyotp
 import pytest
@@ -12,19 +9,18 @@ import vcr
 from requests.exceptions import ConnectTimeout, ReadTimeout
 
 from sdclientapi import API, RequestTimeoutError
-from sdclientapi.sdlocalobjects import (
-    AuthError,
-    Reply,
-    ReplyError,
-    Source,
-    Submission,
-    WrongUUIDError,
-)
+from sdclientapi.sdlocalobjects import AuthError, Reply, Submission
+from test_shared import TestShared
 
 NUM_REPLIES_PER_SOURCE = 2
 
 
-class TestAPI(unittest.TestCase):
+class TestAPI(TestShared):
+    """
+    Note that TestShared contains most of the test code, which is shared between
+    API and API Proxy tests.
+    """
+
     def setUp(self):
         self.totp = pyotp.TOTP("JHCOGO7VCER3EJ4L")
         self.username = "journalist"
@@ -74,230 +70,93 @@ class TestAPI(unittest.TestCase):
             self.api.authenticate()
 
     def test_api_auth(self):
-        self.assertTrue(isinstance(self.api.token, str))
-        self.assertTrue(isinstance(self.api.token_expiration, datetime.datetime))
-        self.assertTrue(isinstance(self.api.token_journalist_uuid, str))
-        self.assertTrue(isinstance(self.api.first_name, (str, type(None))))
-        self.assertTrue(isinstance(self.api.last_name, (str, type(None))))
+        super().api_auth()
 
     @vcr.use_cassette("data/test-seen.yml")
     def test_seen(self):
-        submissions = self.api.get_all_submissions()
-        replies = self.api.get_all_replies()
-
-        file_uuids = []
-        message_uuids = []
-        reply_uuids = []
-
-        for submission in submissions:
-            if submission.is_file():
-                file_uuids.append(submission.uuid)
-            else:
-                message_uuids.append(submission.uuid)
-
-        for reply in replies:
-            reply_uuids.append(reply.uuid)
-
-        self.assertTrue(
-            self.api.seen(files=file_uuids, messages=message_uuids, replies=reply_uuids)
-        )
+        super().seen()
 
     @vcr.use_cassette("data/test-get-sources.yml")
     def test_get_sources(self):
-        sources = self.api.get_sources()
-        for source in sources:
-            # Assert expected fields are present
-            assert source.journalist_designation
-            assert source.uuid
-            assert source.last_updated
+        super().get_sources()
 
     @vcr.use_cassette("data/test-star-add-remove.yml")
     def test_star_add_remove(self):
-        s = self.api.get_sources()[0]
-        self.assertTrue(self.api.add_star(s))
-        self.assertTrue(self.api.remove_star(s))
-        for source in self.api.get_sources():
-            if source.uuid == s.uuid:
-                self.assertFalse(source.is_starred)
+        super().star_add_remove()
 
     @vcr.use_cassette("data/test-get-single-source.yml")
     def test_get_single_source(self):
-        s = self.api.get_sources()[0]
-        # Now we will try to get the same source again
-        s2 = self.api.get_source(s)
-
-        self.assertEqual(s.journalist_designation, s2.journalist_designation)
-        self.assertEqual(s.uuid, s2.uuid)
+        super().get_single_source()
 
     @vcr.use_cassette("data/test-get-single-source.yml")
     def test_get_single_source_from_string(self):
-        s = self.api.get_sources()[0]
-        # Now we will try to get the same source again using uuid
-        s2 = self.api.get_source_from_string(s.uuid)
-
-        self.assertEqual(s.journalist_designation, s2.journalist_designation)
-        self.assertEqual(s.uuid, s2.uuid)
+        super().get_single_source(from_string=True)
 
     @vcr.use_cassette("data/test-failed-single-source.yml")
     def test_failed_single_source(self):
-        with self.assertRaises(WrongUUIDError):
-            self.api.get_source(Source(uuid="not there"))
+        super().failed_single_source()
 
     @vcr.use_cassette("data/test-get-submissions.yml")
     def test_get_submissions(self):
-        s = self.api.get_sources()[0]
-
-        subs = self.api.get_submissions(s)
-        for submission in subs:
-            assert submission.filename
+        super().get_submissions()
 
     @vcr.use_cassette("data/test-get-submission.yml")
     def test_get_submission(self):
-        # Get a source with submissions
-        source_uuid = self.api.get_all_submissions()[0].source_uuid
-        s = self.api.get_source(Source(uuid=source_uuid))
-
-        subs = self.api.get_submissions(s)
-        sub = self.api.get_submission(subs[0])
-        self.assertEqual(sub.filename, subs[0].filename)
+        super().get_submission()
 
     @vcr.use_cassette("data/test-get-submission.yml")
     def test_get_submission_from_string(self):
-        # Get a source with submissions
-        source_uuid = self.api.get_all_submissions()[0].source_uuid
-        s = self.api.get_source(Source(uuid=source_uuid))
-
-        subs = self.api.get_submissions(s)
-        sub = self.api.get_submission_from_string(subs[0].uuid, s.uuid)
-        self.assertEqual(sub.filename, subs[0].filename)
+        super().get_submission(from_string=True)
 
     @vcr.use_cassette("data/test-get-wrong-submissions.yml")
     def test_get_wrong_submissions(self):
-        s = self.api.get_sources()[0]
-        s.uuid = "rofl-missing"
-        with self.assertRaises(WrongUUIDError):
-            self.api.get_submissions(s)
+        super().get_wrong_submissions()
 
     @vcr.use_cassette("data/test-get-all-submissions.yml")
     def test_get_all_submissions(self):
-        subs = self.api.get_all_submissions()
-        for submission in subs:
-            assert submission.filename
+        super().get_all_submissions()
 
     @vcr.use_cassette("data/test-flag-source.yml")
     def test_flag_source(self):
-        s = self.api.get_sources()[0]
-        self.assertTrue(self.api.flag_source(s))
-        # Now we will try to get the same source again
-        s2 = self.api.get_source(s)
-        self.assertTrue(s2.is_flagged)
+        super().flag_source()
 
     @vcr.use_cassette("data/test-delete-source.yml")
     def test_delete_source(self):
-        number_of_sources_before = len(self.api.get_sources())
-
-        s = self.api.get_sources()[0]
-        self.assertTrue(self.api.delete_source(s))
-
-        # Now there should be one less source
-        sources = self.api.get_sources()
-        self.assertEqual(len(sources), number_of_sources_before - 1)
+        super().delete_source()
 
     @vcr.use_cassette("data/test-delete-source.yml")
     def test_delete_source_from_string(self):
-        number_of_sources_before = len(self.api.get_sources())
-
-        s = self.api.get_sources()[0]
-        self.assertTrue(self.api.delete_source_from_string(s.uuid))
-
-        # Now there should be one less source
-        sources = self.api.get_sources()
-        self.assertEqual(len(sources), number_of_sources_before - 1)
+        super().delete_source(from_string=True)
 
     @vcr.use_cassette("data/test-delete-submission.yml")
     def test_delete_submission(self):
-        number_of_submissions_before = len(self.api.get_all_submissions())
-
-        subs = self.api.get_all_submissions()
-        self.assertTrue(self.api.delete_submission(subs[0]))
-        new_subs = self.api.get_all_submissions()
-        # We now should have 1 less submission
-        self.assertEqual(len(new_subs), number_of_submissions_before - 1)
-
-        # Let us make sure that sub[0] is not there
-        for s in new_subs:
-            self.assertNotEqual(s.uuid, subs[0].uuid)
+        super().delete_submission()
 
     @vcr.use_cassette("data/test-delete-submission-from-string.yml")
     def test_delete_submission_from_string(self):
-        number_of_submissions_before = len(self.api.get_all_submissions())
-
-        s = self.api.get_sources()[0]
-
-        subs = self.api.get_submissions(s)
-
-        self.assertTrue(self.api.delete_submission(subs[0]))
-        new_subs = self.api.get_all_submissions()
-        # We now should have 1 less submission
-        self.assertEqual(len(new_subs), number_of_submissions_before - 1)
-
-        # Let us make sure that sub[0] is not there
-        for s in new_subs:
-            self.assertNotEqual(s.uuid, subs[0].uuid)
+        super().delete_submission(from_string=True)
 
     @vcr.use_cassette("data/test-get-current-user.yml")
     def test_get_current_user(self):
-        user = self.api.get_current_user()
-        self.assertTrue(user["is_admin"])
-        self.assertEqual(user["username"], "journalist")
-        self.assertTrue("first_name" in user)
-        self.assertTrue("last_name" in user)
+        super().get_current_user()
 
     @vcr.use_cassette("data/test-get-users.yml")
     def test_get_users(self):
-        users = self.api.get_users()
-        for user in users:
-            # Assert expected fields are present
-            assert hasattr(user, "first_name")
-            assert hasattr(user, "last_name")
-            # Every user has a non-empty name and UUID
-            assert user.username
-            assert user.uuid
-            # The API should never return these fields
-            assert not hasattr(user, "last_login")
-            assert not hasattr(user, "is_admin")
+        super().get_users()
 
     @vcr.use_cassette("data/test-error-unencrypted-reply.yml")
     def test_error_unencrypted_reply(self):
-        s = self.api.get_sources()[0]
-        with self.assertRaises(ReplyError) as err:
-            self.api.reply_source(s, "hello")
-
-        self.assertEqual(err.exception.msg, "bad request")
+        super().error_unencrypted_reply()
 
     @vcr.use_cassette("data/test-reply-source.yml")
     def test_reply_source(self):
-        s = self.api.get_sources()[0]
-        dirname = os.path.dirname(__file__)
-        with open(os.path.join(dirname, "encrypted_msg.asc")) as fobj:
-            data = fobj.read()
-
-        reply = self.api.reply_source(s, data)
-        assert isinstance(reply, Reply)
-        assert reply.uuid
-        assert reply.filename
+        super().reply_source()
 
     @vcr.use_cassette("data/test-reply-source-with-uuid.yml")
     def test_reply_source_with_uuid(self):
-        s = self.api.get_sources()[0]
-        dirname = os.path.dirname(__file__)
-        with open(os.path.join(dirname, "encrypted_msg.asc")) as fobj:
-            data = fobj.read()
+        super().reply_source_with_uuid()
 
-        msg_uuid = "e467868c-1fbb-4b5e-bca2-87944ea83855"
-        reply = self.api.reply_source(s, data, msg_uuid)
-        assert reply.uuid == msg_uuid
-
+    # This test is materially different in the API & API Proxy versions.
     @vcr.use_cassette("data/test-download-submission.yml")
     def test_download_submission(self):
         submissions = self.api.get_all_submissions()
@@ -335,29 +194,17 @@ class TestAPI(unittest.TestCase):
 
     @vcr.use_cassette("data/test-get-replies-from-source.yml")
     def test_get_replies_from_source(self):
-        s = self.api.get_sources()[0]
-        replies = self.api.get_replies_from_source(s)
-        self.assertEqual(len(replies), NUM_REPLIES_PER_SOURCE)
+        super().get_replies_from_source()
 
     @vcr.use_cassette("data/test-get-reply-from-source.yml")
     def test_get_reply_from_source(self):
-        s = self.api.get_sources()[0]
-        replies = self.api.get_replies_from_source(s)
-        reply = replies[0]
-
-        r = self.api.get_reply_from_source(s, reply.uuid)
-
-        self.assertEqual(reply.filename, r.filename)
-        self.assertEqual(reply.size, r.size)
-        self.assertEqual(reply.reply_url, r.reply_url)
-        self.assertEqual(reply.journalist_username, r.journalist_username)
+        super().get_reply_from_source()
 
     @vcr.use_cassette("data/test-get-all-replies.yml")
     def test_get_all_replies(self):
-        num_sources = len(self.api.get_sources())
-        replies = self.api.get_all_replies()
-        self.assertEqual(len(replies), NUM_REPLIES_PER_SOURCE * num_sources)
+        super().get_all_replies()
 
+    # This test is materially different in the API & API Proxy versions.
     @vcr.use_cassette("data/test-download-reply.yml")
     def test_download_reply(self):
         r = self.api.get_all_replies()[0]
@@ -381,14 +228,7 @@ class TestAPI(unittest.TestCase):
 
     @vcr.use_cassette("data/test-delete-reply.yml")
     def test_delete_reply(self):
-        r = self.api.get_all_replies()[0]
-
-        number_of_replies_before = len(self.api.get_all_replies())
-
-        self.assertTrue(self.api.delete_reply(r))
-
-        # We deleted one, so there must be 1 less reply now
-        self.assertEqual(len(self.api.get_all_replies()), number_of_replies_before - 1)
+        super().delete_reply()
 
     @vcr.use_cassette("data/test-logout.yml")
     def test_zlogout(self):

--- a/tests/test_apiproxy.py
+++ b/tests/test_apiproxy.py
@@ -1,31 +1,26 @@
-import datetime
 import http
 import json
 import os
 import shutil
 import tempfile
 import time
-import unittest
 from subprocess import TimeoutExpired
 
 import pyotp
 import pytest
 
 from sdclientapi import API, RequestTimeoutError
-from sdclientapi.sdlocalobjects import (
-    BaseError,
-    Reply,
-    ReplyError,
-    Source,
-    Submission,
-    WrongUUIDError,
-)
+from sdclientapi.sdlocalobjects import BaseError, Reply, Submission
+from test_shared import TestShared
 from utils import dastollervey_datasaver, load_auth, save_auth
 
-NUM_REPLIES_PER_SOURCE = 2
 
+class TestAPIProxy(TestShared):
+    """
+    Note that TestShared contains most of the test code, which is shared between
+    API and API Proxy tests.
+    """
 
-class TestAPIProxy(unittest.TestCase):
     @dastollervey_datasaver
     def setUp(self):
         self.totp = pyotp.TOTP("JHCOGO7VCER3EJ4L")
@@ -62,230 +57,124 @@ class TestAPIProxy(unittest.TestCase):
             break
 
     def test_api_auth(self):
-
-        self.assertTrue(isinstance(self.api.token, str))
-        self.assertTrue(isinstance(self.api.token_expiration, datetime.datetime))
-        self.assertTrue(isinstance(self.api.token_journalist_uuid, str))
-        self.assertTrue(isinstance(self.api.first_name, (str, type(None))))
-        self.assertTrue(isinstance(self.api.last_name, (str, type(None))))
+        super().api_auth()
 
     @dastollervey_datasaver
     def test_seen(self):
-        submissions = self.api.get_all_submissions()
-        replies = self.api.get_all_replies()
-
-        file_uuids = []
-        message_uuids = []
-        reply_uuids = []
-
-        for submission in submissions:
-            if submission.is_file():
-                file_uuids.append(submission.uuid)
-            else:
-                message_uuids.append(submission.uuid)
-
-        for reply in replies:
-            reply_uuids.append(reply.uuid)
-
-        self.assertTrue(
-            self.api.seen(files=file_uuids, messages=message_uuids, replies=reply_uuids)
-        )
+        super().seen()
 
     @dastollervey_datasaver
     def test_get_sources(self):
-        sources = self.api.get_sources()
-        for source in sources:
-            # Assert expected fields are present
-            assert source.journalist_designation
-            assert source.uuid
-            assert source.last_updated
+        super().get_sources()
 
     @dastollervey_datasaver
     def test_star_add_remove(self):
-        s = self.api.get_sources()[0]
-        self.assertTrue(self.api.add_star(s))
-        self.assertTrue(self.api.remove_star(s))
-        for source in self.api.get_sources():
-            if source.uuid == s.uuid:
-                self.assertFalse(source.is_starred)
+        super().star_add_remove()
 
     @dastollervey_datasaver
     def test_get_single_source(self):
-        s = self.api.get_sources()[0]
-        # Now we will try to get the same source again
-        s2 = self.api.get_source(s)
-
-        self.assertEqual(s.journalist_designation, s2.journalist_designation)
-        self.assertEqual(s.uuid, s2.uuid)
+        super().get_single_source()
 
     @dastollervey_datasaver
     def test_get_single_source_from_string(self):
-        s = self.api.get_sources()[0]
-        # Now we will try to get the same source again using uuid
-        s2 = self.api.get_source_from_string(s.uuid)
-
-        self.assertEqual(s.journalist_designation, s2.journalist_designation)
-        self.assertEqual(s.uuid, s2.uuid)
+        super().get_single_source(from_string=True)
 
     @dastollervey_datasaver
     def test_failed_single_source(self):
-        with self.assertRaises(WrongUUIDError):
-            self.api.get_source(Source(uuid="not there"))
+        super().failed_single_source()
 
     @dastollervey_datasaver
     def test_get_submissions(self):
-        s = self.api.get_sources()[0]
-
-        subs = self.api.get_submissions(s)
-        for submission in subs:
-            assert submission.filename
+        super().get_submissions()
 
     @dastollervey_datasaver
     def test_get_submission(self):
-        # Get a source with submissions
-        source_uuid = self.api.get_all_submissions()[0].source_uuid
-        s = self.api.get_source(Source(uuid=source_uuid))
-
-        subs = self.api.get_submissions(s)
-        sub = self.api.get_submission(subs[0])
-        self.assertEqual(sub.filename, subs[0].filename)
+        super().get_submission()
 
     @dastollervey_datasaver
     def test_get_submission_from_string(self):
-        # Get a source with submissions
-        source_uuid = self.api.get_all_submissions()[0].source_uuid
-        s = self.api.get_source(Source(uuid=source_uuid))
-
-        subs = self.api.get_submissions(s)
-        sub = self.api.get_submission_from_string(subs[0].uuid, s.uuid)
-        self.assertEqual(sub.filename, subs[0].filename)
+        super().get_submission(from_string=True)
 
     @dastollervey_datasaver
     def test_get_wrong_submissions(self):
-        s = self.api.get_sources()[0]
-        s.uuid = "rofl-missing"
-        with self.assertRaises(WrongUUIDError):
-            self.api.get_submissions(s)
+        super().get_wrong_submissions()
 
     @dastollervey_datasaver
     def test_get_all_submissions(self):
-        subs = self.api.get_all_submissions()
-        for submission in subs:
-            assert submission.filename
+        super().get_all_submissions()
 
     @dastollervey_datasaver
     def test_flag_source(self):
-        s = self.api.get_sources()[0]
-        self.assertTrue(self.api.flag_source(s))
-        # Now we will try to get the same source again
-        s2 = self.api.get_source(s)
-        self.assertTrue(s2.is_flagged)
+        super().flag_source()
 
     @dastollervey_datasaver
     def test_delete_source(self):
-        number_of_sources_before = len(self.api.get_sources())
-
-        s = self.api.get_sources()[0]
-        self.assertTrue(self.api.delete_source(s))
-
-        # Now there should be one less source
-        sources = self.api.get_sources()
-        self.assertEqual(len(sources), number_of_sources_before - 1)
+        super().delete_source()
 
     @dastollervey_datasaver
     def test_delete_source_from_string(self):
-        number_of_sources_before = len(self.api.get_sources())
-
-        s = self.api.get_sources()[0]
-        self.assertTrue(self.api.delete_source_from_string(s.uuid))
-
-        # Now there should be one less source
-        sources = self.api.get_sources()
-        self.assertEqual(len(sources), number_of_sources_before - 1)
+        super().delete_source(from_string=True)
 
     @dastollervey_datasaver
     def test_delete_submission(self):
-        number_of_submissions_before = len(self.api.get_all_submissions())
-
-        subs = self.api.get_all_submissions()
-        self.assertTrue(self.api.delete_submission(subs[0]))
-        new_subs = self.api.get_all_submissions()
-        # We now should have 1 less submission
-        self.assertEqual(len(new_subs), number_of_submissions_before - 1)
-
-        # Let us make sure that sub[0] is not there
-        for s in new_subs:
-            self.assertNotEqual(s.uuid, subs[0].uuid)
+        super().delete_submission()
 
     @dastollervey_datasaver
     def test_delete_submission_from_string(self):
-        number_of_submissions_before = len(self.api.get_all_submissions())
-
-        s = self.api.get_sources()[0]
-
-        subs = self.api.get_submissions(s)
-
-        self.assertTrue(self.api.delete_submission(subs[0]))
-        new_subs = self.api.get_all_submissions()
-        # We now should have 1 less submission
-        self.assertEqual(len(new_subs), number_of_submissions_before - 1)
-
-        # Let us make sure that sub[0] is not there
-        for s in new_subs:
-            self.assertNotEqual(s.uuid, subs[0].uuid)
+        super().delete_submission(from_string=True)
 
     @dastollervey_datasaver
     def test_get_current_user(self):
-        user = self.api.get_current_user()
-        self.assertTrue(user["is_admin"])
-        self.assertEqual(user["username"], "journalist")
-        self.assertTrue("first_name" in user)
-        self.assertTrue("last_name" in user)
+        super().get_current_user()
 
     @dastollervey_datasaver
     def test_get_users(self):
-        users = self.api.get_users()
-        for user in users:
-            # Assert expected fields are present
-            assert hasattr(user, "first_name")
-            assert hasattr(user, "last_name")
-            # Every user has a non-empty name and UUID
-            assert user.username
-            assert user.uuid
-            # The API should never return these fields
-            assert not hasattr(user, "last_login")
-            assert not hasattr(user, "is_admin")
+        super().get_users()
 
     @dastollervey_datasaver
     def test_error_unencrypted_reply(self):
-        s = self.api.get_sources()[0]
-        with self.assertRaises(ReplyError) as err:
-            self.api.reply_source(s, "hello")
-
-        self.assertEqual(err.exception.msg, "bad request")
+        super().error_unencrypted_reply()
 
     @dastollervey_datasaver
     def test_reply_source(self):
-        s = self.api.get_sources()[0]
-        dirname = os.path.dirname(__file__)
-        with open(os.path.join(dirname, "encrypted_msg.asc")) as fobj:
-            data = fobj.read()
-
-        reply = self.api.reply_source(s, data)
-        assert isinstance(reply, Reply)
-        assert reply.uuid
-        assert reply.filename
+        super().reply_source()
 
     @dastollervey_datasaver
     def test_reply_source_with_uuid(self):
-        s = self.api.get_sources()[0]
-        dirname = os.path.dirname(__file__)
-        with open(os.path.join(dirname, "encrypted_msg.asc")) as fobj:
-            data = fobj.read()
+        super().reply_source_with_uuid()
 
-        msg_uuid = "e467868c-1fbb-4b5e-bca2-87944ea83855"
-        reply = self.api.reply_source(s, data, msg_uuid)
-        assert reply.uuid == msg_uuid
+    @dastollervey_datasaver
+    def test_get_replies_from_source(self):
+        super().get_replies_from_source()
+
+    @dastollervey_datasaver
+    def test_get_reply_from_source(self):
+        super().get_reply_from_source()
+
+    @dastollervey_datasaver
+    def test_get_all_replies(self):
+        super().get_all_replies()
+
+    @dastollervey_datasaver
+    def test_delete_reply(self):
+        super().delete_reply()
+
+    @dastollervey_datasaver
+    def test_download_reply(self):
+        r = self.api.get_all_replies()[0]
+
+        # We need a temporary directory to download
+        tmpdir = tempfile.mkdtemp()
+        _, filepath = self.api.download_reply(r, tmpdir)
+
+        # Uncomment the following part only on QubesOS
+        # for testing against real server.
+        # now let us read the downloaded file
+        # with open(filepath, "rb") as fobj:
+        #     fobj.read()
+
+        # Let us remove the temporary directory
+        shutil.rmtree(tmpdir)
 
     @dastollervey_datasaver
     def test_download_submission(self):
@@ -310,59 +199,6 @@ class TestAPIProxy(unittest.TestCase):
 
         # Let us remove the temporary directory
         shutil.rmtree(tmpdir)
-
-    @dastollervey_datasaver
-    def test_get_replies_from_source(self):
-        s = self.api.get_sources()[0]
-        replies = self.api.get_replies_from_source(s)
-        self.assertEqual(len(replies), NUM_REPLIES_PER_SOURCE)
-
-    @dastollervey_datasaver
-    def test_get_reply_from_source(self):
-        s = self.api.get_sources()[0]
-        replies = self.api.get_replies_from_source(s)
-        reply = replies[0]
-
-        r = self.api.get_reply_from_source(s, reply.uuid)
-
-        self.assertEqual(reply.filename, r.filename)
-        self.assertEqual(reply.size, r.size)
-        self.assertEqual(reply.reply_url, r.reply_url)
-        self.assertEqual(reply.journalist_username, r.journalist_username)
-
-    @dastollervey_datasaver
-    def test_get_all_replies(self):
-        num_sources = len(self.api.get_sources())
-        replies = self.api.get_all_replies()
-        self.assertEqual(len(replies), NUM_REPLIES_PER_SOURCE * num_sources)
-
-    @dastollervey_datasaver
-    def test_download_reply(self):
-        r = self.api.get_all_replies()[0]
-
-        # We need a temporary directory to download
-        tmpdir = tempfile.mkdtemp()
-        _, filepath = self.api.download_reply(r, tmpdir)
-
-        # Uncomment the following part only on QubesOS
-        # for testing against real server.
-        # now let us read the downloaded file
-        # with open(filepath, "rb") as fobj:
-        #     fobj.read()
-
-        # Let us remove the temporary directory
-        shutil.rmtree(tmpdir)
-
-    @dastollervey_datasaver
-    def test_delete_reply(self):
-        r = self.api.get_all_replies()[0]
-
-        number_of_replies_before = len(self.api.get_all_replies())
-
-        self.assertTrue(self.api.delete_reply(r))
-
-        # We deleted one, so there must be 1 less reply now
-        self.assertEqual(len(self.api.get_all_replies()), number_of_replies_before - 1)
 
     @dastollervey_datasaver
     def test_logout(self):

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -1,0 +1,236 @@
+import datetime
+import os
+import unittest
+
+from sdclientapi.sdlocalobjects import Reply, ReplyError, Source, WrongUUIDError
+
+NUM_REPLIES_PER_SOURCE = 2
+
+
+class TestShared(unittest.TestCase):
+    """
+    Base class for test code that is shared by the API and API proxy tests.
+    Tests in this file should not be prefixed with test_; they are called
+    only from subclasses.
+    """
+
+    # ---------------- AUTH ----------------
+
+    def api_auth(self):
+        self.assertTrue(isinstance(self.api.token, str))
+        self.assertTrue(isinstance(self.api.token_expiration, datetime.datetime))
+        self.assertTrue(isinstance(self.api.token_journalist_uuid, str))
+        self.assertTrue(isinstance(self.api.first_name, (str, type(None))))
+        self.assertTrue(isinstance(self.api.last_name, (str, type(None))))
+
+    # ---------------- SOURCES ----------------
+
+    def delete_source(self, from_string=False):
+        number_of_sources_before = len(self.api.get_sources())
+
+        s = self.api.get_sources()[0]
+        if from_string:
+            self.assertTrue(self.api.delete_source_from_string(s.uuid))
+        else:
+            self.assertTrue(self.api.delete_source(s))
+
+        # Now there should be one less source
+        sources = self.api.get_sources()
+        self.assertEqual(len(sources), number_of_sources_before - 1)
+
+    def failed_single_source(self):
+        with self.assertRaises(WrongUUIDError):
+            self.api.get_source(Source(uuid="not there"))
+
+    def flag_source(self):
+        s = self.api.get_sources()[0]
+        self.assertTrue(self.api.flag_source(s))
+        # Now we will try to get the same source again
+        s2 = self.api.get_source(s)
+        self.assertTrue(s2.is_flagged)
+
+    def get_single_source(self, from_string=False):
+        s = self.api.get_sources()[0]
+        # Now we will try to get the same source again
+
+        if from_string:
+            s2 = self.api.get_source_from_string(s.uuid)
+        else:
+            s2 = self.api.get_source(s)
+
+        self.assertEqual(s.journalist_designation, s2.journalist_designation)
+        self.assertEqual(s.uuid, s2.uuid)
+
+    def get_sources(self):
+        sources = self.api.get_sources()
+        for source in sources:
+            # Assert expected fields are present
+            assert source.journalist_designation
+            assert source.uuid
+            assert source.last_updated
+
+    # ---------------- SUBMISSIONS ----------------
+
+    def delete_submission(self, from_string=False):
+        number_of_submissions_before = len(self.api.get_all_submissions())
+
+        if from_string:
+            s = self.api.get_sources()[0]
+            subs = self.api.get_submissions(s)
+        else:
+            subs = self.api.get_all_submissions()
+        self.assertTrue(self.api.delete_submission(subs[0]))
+        new_subs = self.api.get_all_submissions()
+        # We now should have 1 less submission
+        self.assertEqual(len(new_subs), number_of_submissions_before - 1)
+
+        # Let us make sure that sub[0] is not there
+        for s in new_subs:
+            self.assertNotEqual(s.uuid, subs[0].uuid)
+
+    def get_submission(self, from_string=False):
+        # Get a source with submissions
+        source_uuid = self.api.get_all_submissions()[0].source_uuid
+        s = self.api.get_source(Source(uuid=source_uuid))
+
+        subs = self.api.get_submissions(s)
+        if from_string:
+            sub = self.api.get_submission_from_string(subs[0].uuid, s.uuid)
+        else:
+            sub = self.api.get_submission(subs[0])
+
+        self.assertEqual(sub.filename, subs[0].filename)
+
+    def get_all_submissions(self):
+        subs = self.api.get_all_submissions()
+        for submission in subs:
+            assert submission.filename
+
+    def get_submissions(self):
+        s = self.api.get_sources()[0]
+        subs = self.api.get_submissions(s)
+        for submission in subs:
+            assert submission.filename
+
+    def get_wrong_submissions(self):
+        s = self.api.get_sources()[0]
+        s.uuid = "rofl-missing"
+        with self.assertRaises(WrongUUIDError):
+            self.api.get_submissions(s)
+
+    # ---------------- REPLIES ----------------
+
+    def error_unencrypted_reply(self):
+        s = self.api.get_sources()[0]
+        with self.assertRaises(ReplyError) as err:
+            self.api.reply_source(s, "hello")
+
+        self.assertEqual(err.exception.msg, "bad request")
+
+    def delete_reply(self):
+        r = self.api.get_all_replies()[0]
+
+        number_of_replies_before = len(self.api.get_all_replies())
+
+        self.assertTrue(self.api.delete_reply(r))
+
+        # We deleted one, so there must be 1 less reply now
+        self.assertEqual(len(self.api.get_all_replies()), number_of_replies_before - 1)
+
+    def get_replies_from_source(self):
+        s = self.api.get_sources()[0]
+        replies = self.api.get_replies_from_source(s)
+        self.assertEqual(len(replies), NUM_REPLIES_PER_SOURCE)
+
+    def get_reply_from_source(self):
+        s = self.api.get_sources()[0]
+        replies = self.api.get_replies_from_source(s)
+        reply = replies[0]
+
+        r = self.api.get_reply_from_source(s, reply.uuid)
+
+        self.assertEqual(reply.filename, r.filename)
+        self.assertEqual(reply.size, r.size)
+        self.assertEqual(reply.reply_url, r.reply_url)
+        self.assertEqual(reply.journalist_username, r.journalist_username)
+
+    def get_all_replies(self):
+        num_sources = len(self.api.get_sources())
+        replies = self.api.get_all_replies()
+        self.assertEqual(len(replies), NUM_REPLIES_PER_SOURCE * num_sources)
+
+    def reply_source(self):
+        s = self.api.get_sources()[0]
+        dirname = os.path.dirname(__file__)
+        with open(os.path.join(dirname, "encrypted_msg.asc")) as fobj:
+            data = fobj.read()
+
+        reply = self.api.reply_source(s, data)
+        assert isinstance(reply, Reply)
+        assert reply.uuid
+        assert reply.filename
+
+    def reply_source_with_uuid(self):
+        s = self.api.get_sources()[0]
+        dirname = os.path.dirname(__file__)
+        with open(os.path.join(dirname, "encrypted_msg.asc")) as fobj:
+            data = fobj.read()
+
+        msg_uuid = "e467868c-1fbb-4b5e-bca2-87944ea83855"
+        reply = self.api.reply_source(s, data, msg_uuid)
+        assert reply.uuid == msg_uuid
+
+    # ---------------- USERS ----------------
+
+    def get_current_user(self):
+        user = self.api.get_current_user()
+        self.assertTrue(user["is_admin"])
+        self.assertEqual(user["username"], "journalist")
+        self.assertTrue("first_name" in user)
+        self.assertTrue("last_name" in user)
+
+    def get_users(self):
+        users = self.api.get_users()
+        for user in users:
+            # Assert expected fields are present
+            assert hasattr(user, "first_name")
+            assert hasattr(user, "last_name")
+            # Every user has a non-empty name and UUID
+            assert user.username
+            assert user.uuid
+            # The API should never return these fields
+            assert not hasattr(user, "last_login")
+            assert not hasattr(user, "is_admin")
+
+    # ---------------- SEEN/UNSEEN ----------------
+
+    def seen(self):
+        submissions = self.api.get_all_submissions()
+        replies = self.api.get_all_replies()
+
+        file_uuids = []
+        message_uuids = []
+        reply_uuids = []
+
+        for submission in submissions:
+            if submission.is_file():
+                file_uuids.append(submission.uuid)
+            else:
+                message_uuids.append(submission.uuid)
+
+        for reply in replies:
+            reply_uuids.append(reply.uuid)
+
+        self.assertTrue(
+            self.api.seen(files=file_uuids, messages=message_uuids, replies=reply_uuids)
+        )
+
+    # ---------------- STARRING ----------------
+
+    def star_add_remove(self):
+        s = self.api.get_sources()[0]
+        self.assertTrue(self.api.add_star(s))
+        self.assertTrue(self.api.remove_star(s))
+        for source in self.api.get_sources():
+            if source.uuid == s.uuid:
+                self.assertFalse(source.is_starred)


### PR DESCRIPTION
Resolves #67 (still some remaining room for improvement, but this takes care of the obvious duplication).

In addition to sub-classing from TestShared, I've refactored the `from_string` variants of the test. This is a good candidate for `pytest.mark.parametrize` for further light refactoring, but that [conflicts](https://stackoverflow.com/questions/18182251/does-pytest-parametrized-test-work-with-unittest-class-based-tests) with the current use of `unittest.TestCase`.

The other obvious area to refactor is the setup and teardown, but since those are in fact materially different between API and API proxy tests, that will be a somewhat bigger lift.

## Test plan

- [ ] Observe that tests pass locally and in CI
- [ ] Observe that test output is identical to the test output in `main`
- [ ] Delete and regenerate YML cassettes per instructions in README and observe that tests still pass
- [ ] Delete and regenerate JSON cassettes per instructions in README and observe that tests still pass (requires Qubes)