### PR TITLE
Release securedrop-sdk 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.3.0
+-----
+
+* Support "delete_conversation " endpoint (#158)
+
 0.2.0
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="securedrop-sdk",
-    version="0.2.0",
+    version="0.3.0",
     author="Freedom of the Press Foundation",
     author_email="securedrop@freedom.press",
     description="Python client API to access SecureDrop Journalist REST API",


### PR DESCRIPTION
## Description

Time to cut a new release of the sdk so we can use the new /delete-conversation endpoint in the SecureDrop Client.

Towards https://github.com/freedomofpress/securedrop-sdk/issues/160

## Test Plan

- [ ] `CHANGELOG.md` and `setup.py` have been updated to point to version 0.3.0 with correct changelog details
- Once this is merged, continue to work towards #160 via steps outlined here: https://github.com/freedomofpress/securedrop-sdk#releasing