### PR TITLE
update readme for quicker quick start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@ The SDK is currently used by the [SecureDrop Client](https://github.com/freedomo
 # Quick Start
 
 ```bash
-virtualenv --python=python3 .venv
+make venv
 source .venv/bin/activate
-pip install --require-hashes -r dev-requirements.txt
 make test
 ```
 


### PR DESCRIPTION
## Description

Once our `make venv` bug is fixed (see https://github.com/freedomofpress/securedrop-sdk/pull/162), this readme change can go in so that we make sure all devs are using the same developer setup instructions.