### PR TITLE
Adds upgrade-pip makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,12 @@ update-pip-requirements: ## Updates all Python requirements files via pip-compil
 	pip-compile --generate-hashes --output-file dev-requirements.txt requirements.in dev-requirements.in
 	pip-compile --generate-hashes --output-file requirements.txt requirements.in
 
+
+.PHONY: upgrade-pip
+upgrade-pip: ## Upgrade one single package via pip-compile
+	pip-compile --generate-hashes --upgrade-package $(PACKAGE) --output-file dev-requirements.txt requirements.in dev-requirements.in
+	pip-compile --generate-hashes --upgrade-package $(PACKAGE) --output-file requirements.txt requirements.in
+
 .PHONY: open-coverage-report
 open-coverage-report: ## Open the coverage report in your browser
 	@$(OPEN) htmlcov/index.html

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ pip uninstall securedrop-sdk
 pip install git+https://github.com/freedomofpress/securedrop-sdk@my_branch#egg=securedrop-sdk
 ```
 
+# Upgrading one single dependency
+
+To upgrade one single Python dependency, say `requests`, run the following:
+
+```bash
+PACKAGE=requests make upgrade-pip
+```
+
+This will upgrade both `dev-requirements` and primary `requirements`.
+
 # Running tests
 
 To run all tests and checks, run:


### PR DESCRIPTION
One can now upgrade one particular dependency via
`PACKAGE=pacakgename make upgrade-pip` command.

The commit also has updated README for the same.

## How to test?

- [ ] Update `requirements.in` file to mark `requests>=2.22.0`
- [ ] Run `PACKAGE=requests make upgrade-pip`
- [ ] Verify in the `requirements.txt` and `dev-requirements.txt` files that the `requests` and related dependencies upgraded properly.