### PR TITLE
Release securedrop-sdk 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.3.1
+-----
+
+* Update urllib3 to 1.26.6 to address CVE-2021-33503 (#166)
+* Update certifi to 2021.5.30, idna to 2.8, requests to 2.26.0 (#167)
+ 
 0.3.0
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="securedrop-sdk",
-    version="0.3.0",
+    version="0.3.1",
     author="Freedom of the Press Foundation",
     author_email="securedrop@freedom.press",
     description="Python client API to access SecureDrop Journalist REST API",


### PR DESCRIPTION
## Description

Time to cut a new release of the sdk to include dependency updates.

## Test Plan

- [ ] `CHANGELOG.md` and `setup.py` have been updated to point to version 0.3.1 with correct changelog details
