### PR TITLE
Update Fetching Sdk Objects

### DIFF
--- a/sdclientapi/__init__.py
+++ b/sdclientapi/__init__.py
@@ -478,17 +478,19 @@ class API:
         :param submission: Submission object we want to update.
         :returns: Updated submission object from the server.
         """
-        path_query = "api/v1/sources/{}/submissions/{}".format(
-            submission.source_uuid, submission.uuid
-        )
-        method = "GET"
+        if submission.source_uuid and submission.uuid is not None:
 
-        data, status_code, headers = self._send_json_request(
-            method,
-            path_query,
-            headers=self.req_headers,
-            timeout=self.default_request_timeout,
-        )
+            path_query = "api/v1/sources/{}/submissions/{}".format(
+                submission.source_uuid, submission.uuid
+            )
+            method = "GET"
+
+            data, status_code, headers = self._send_json_request(
+                method,
+                path_query,
+                headers=self.req_headers,
+                timeout=self.default_request_timeout,
+            )
 
         if status_code == 404:
             raise WrongUUIDError("Missing submission {}".format(submission.uuid))
@@ -760,20 +762,22 @@ class API:
         :param reply_uuid: UUID of the reply.
         :returns: A reply object
         """
-        path_query = "api/v1/sources/{}/replies/{}".format(source.uuid, reply_uuid)
-        method = "GET"
+        if source.uuid and reply_uuid is not None:
 
-        data, status_code, headers = self._send_json_request(
-            method,
-            path_query,
-            headers=self.req_headers,
-            timeout=self.default_request_timeout,
-        )
+            path_query = "api/v1/sources/{}/replies/{}".format(source.uuid, reply_uuid)
+            method = "GET"
 
-        if status_code == 404:
-            raise WrongUUIDError("Missing source {}".format(source.uuid))
+            data, status_code, headers = self._send_json_request(
+                method,
+                path_query,
+                headers=self.req_headers,
+                timeout=self.default_request_timeout,
+            )
 
-        reply = Reply(**data)
+            if status_code == 404:
+                raise WrongUUIDError("Missing source {}".format(source.uuid))
+
+            reply = Reply(**data)
 
         return reply
 
@@ -834,7 +838,9 @@ class API:
 
         if not self.proxy:
             # This is where we will save our downloaded file
-            filepath = os.path.join(path, reply.filename)
+            filepath = os.path.join(
+                path, headers["Content-Disposition"].split("attachment; filename=")[1]
+            )
             with open(filepath, "wb") as fobj:
                 for chunk in data.iter_content(chunk_size=1024):  # Getting 1024 in each chunk
                     if chunk:

--- a/sdclientapi/sdlocalobjects.py
+++ b/sdclientapi/sdlocalobjects.py
@@ -75,6 +75,11 @@ class Reply:
             self.uuid = kwargs["uuid"]
             self.filename = kwargs["filename"]
             return
+           # Fetch an object only by uuid and soure_uuid.
+        elif {"uuid", "source_uuid"} == set(kwargs.keys()):
+            self.uuid = kwargs["uuid"]
+            self.source_uuid = kwargs["source_uuid"]
+            return
 
         for key in [
             "filename",
@@ -116,6 +121,11 @@ class Submission:
         if ["uuid"] == list(kwargs.keys()):
             # Means we are creating an object only for fetching from server.
             self.uuid = kwargs["uuid"]
+            return
+
+        elif ["uuid", "source_uuid"] == list(kwargs.keys()):
+            self.uuid = kwargs["uuid"]
+            self.source_uuid = kwargs["source_uuid"]
             return
 
         for key in [

--- a/sdclientapi/sdlocalobjects.py
+++ b/sdclientapi/sdlocalobjects.py
@@ -75,7 +75,7 @@ class Reply:
             self.uuid = kwargs["uuid"]
             self.filename = kwargs["filename"]
             return
-           # Fetch an object only by uuid and soure_uuid.
+            # Fetch an object only by uuid and soure_uuid.
         elif {"uuid", "source_uuid"} == set(kwargs.keys()):
             self.uuid = kwargs["uuid"]
             self.source_uuid = kwargs["source_uuid"]


### PR DESCRIPTION
Addresses: #94 

Allows Submissions and Replies to be retrieved by only their `uuid` and `source.uuid`
### Testing

Tested against the client and development server using the following branch: https://github.com/nahara7/securedrop-client/tree/nahara/test-sdk and modifying the download call[ here](https://github.com/nahara7/securedrop-client/blob/c6959f36252e85bd44b14a8d6f15a375b6b259f2/securedrop_client/api_jobs/downloads.py#L257.) and[ here](https://github.com/nahara7/securedrop-client/blob/c6959f36252e85bd44b14a8d6f15a375b6b259f2/securedrop_client/api_jobs/downloads.py#L257.): 

