### PR TITLE
Update version and changelog for securedrop-client 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.4.0
+-----
+
+* Ensure support for common date string formats (#172)
+
 0.3.2
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="securedrop-sdk",
-    version="0.3.2",
+    version="0.4.0",
     author="Freedom of the Press Foundation",
     author_email="securedrop@freedom.press",
     description="Python client API to access SecureDrop Journalist REST API",


### PR DESCRIPTION
## Description

Time to cut a new release!

Towards https://github.com/freedomofpress/securedrop-sdk/issues/175

## Test Plan

- [ ] `CHANGELOG.md` and `setup.py` have been updated to version 0.4.0 with correct changelog details
- Once this is merged, continue to work towards https://github.com/freedomofpress/securedrop-sdk/issues/175 via steps outlined here: https://github.com/freedomofpress/securedrop-sdk#releasing