### PR TITLE
Bump python version to 3.9

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 max_line_length = 100
 
 [mypy]
-python_version = 3.5
+python_version = 3.9
 show_column_numbers = True
 show_error_context = True
 disallow_subclassing_any = True

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     license="GPLv3+",
     install_requires=["requests", "urllib3"],
-    python_requires=">=3.5",
+    python_requires=">=3.9",
     url="https://github.com/freedomofpress/securedrop-sdk",
     packages=setuptools.find_packages(exclude=["docs", "tests"]),
     classifiers=(


### PR DESCRIPTION
Not sure that this is really needed, but: since we only support sdk clients on bullseye, and because some dependencies (eg `requests`) have explicitly dropped support for python < 3.6, bump the python version in setup.cfg to 3.9 so it isn't confusing.

In the future, it would probably be better to look at getting rid of setup.cfg and specifying requires-python in the [[project] section of pyproject.toml](https://packaging.python.org/en/latest/specifications/declaring-project-metadata/#declaring-project-metadata).

**Test Plan**
- [x] CI passes and this makes sense