### PR TITLE
Have CI wait for HTTP to be up on server dev environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,8 +56,7 @@ jobs:
       - run:
           name: Wait for server to be up and for test sources to load
           command: |
-            dockerize -wait tcp://127.0.0.1:8080 -timeout 30m
-            sleep 30
+            dockerize -wait http://127.0.0.1:8080 -timeout 30m
       - run:
           name: Remove VCR cassettes and run tests against latest API
           command: |


### PR DESCRIPTION
The tcp port is available as soon as the container is running, but we
actually want to wait for the HTTP server to be up, which means all the
Rust code has been built and sources generated. dockerize already
supports that, we just need to use the "http" protocol instead of "tcp".

This allows us to get rid of the manual "sleep 30" as well.

Fixes #183.
